### PR TITLE
Refactoring Goertzel buffer handling and chat/test state clean-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Acoustic communication is basically the only feasible scheme underwater, and hen
 
 Underwater environments (a) add a lot of noise and (b) distort signals due to reflections.
 
-Here, we use a **FM/AM/OFDM** scheme to send bits.
+Here, we use **binary frequency-shift keying (BFSK)** to send bits. See [Transmit / Receive Signal Flow](#transmit--receive-signal-flow) for how modulation and demodulation work.
 
 ## Subsystems:
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,23 @@ v1.3 pcb
  - [X] make an attempt at a BOM
 
 ---
+## Transmit / Receive Signal Flow
+
+### Signal Modulation Process:
+
+Unkey uses binary frequency-shift keying (BFSK) to transmit data acoustically. Each bit is encoded as a short sine wave at one of two fixed frequencies: one frequency represents a 0, and the other represents a 1. Bits are sent at a fixed bit rate, and bytes are transmitted MSB-first. Each packet begins with a known alternating preamble pattern, followed by framed payload bytes and an explicit footer. The preamble exists solely to help the receiver discover bit timing and alignment before attempting to decode data.
+
+On the transmit side, text messages are packetized into bytes, converted into a bit stream, and then emitted as a sequence of tone windows via the DAC and piezo transducer. Each window contains a single tone corresponding to the current bit.
+
+### Receiver Demodulation Process:
+
+The receiver samples audio continuously using the ADC and DMA, processing fixed-size time windows of samples. For each window, it runs two Goertzel detectors—one tuned to each BFSK frequency—and measures their relative magnitudes. If neither tone is strong enough, the window is treated as noise and ignored.
+
+Rather than assuming fixed timing, the receiver first builds a rolling history of recent window-level tone decisions. Once enough history is collected and the average signal strength is high enough, the receiver searches this history for the known alternating preamble pattern. It does this by trying both possible window alignments and checking for repeated tone flips; when a consistent pattern is found, bit boundaries are considered “locked.”
+
+After timing is locked, each aligned window produces a real bit. These bits are accumulated and scanned for valid packet framing (header and footer). When a complete frame is detected, the payload is extracted, validated, and delivered to the chat system. If the signal weakens or framing fails for too long, the receiver drops alignment and returns to waiting for the preamble.
+
+---
 
 ## Firmware File Organization
 

--- a/README.md
+++ b/README.md
@@ -142,14 +142,14 @@ firmware/
 │   ├── receiving/
 │   │   ├── test_adc_buffer_full_interrupt/
 │   │   │   └── adc_buffer_full_interrupt.cpp
-│   │   ├── test_decode_single_bit_from_adc_window/
-│   │   │   └── decode_single_bit_from_adc_window.cpp
+│   │   ├── test_check_for_complete_packet/
+│   │   │   └── check_for_complete_packet.cpp
 │   │   ├── test_deliver_message/
 │   │   │   └── deliver_message.cpp
 │   │   ├── test_get_bit_from_top_frequency/
 │   │   │   └── get_bit_from_top_frequency.cpp
-│   │   ├── test_parse_message/
-│   │   │   └── parse_message.cpp
+│   │   ├── test_decode_single_bit_from_adc_window/
+│   │   │   └── decode_single_bit_from_adc_window.cpp
 │   ├── transmitting/
 │   │   └── test_packetize_message/
 │   │       └── packetize_message.cpp

--- a/firmware/include/comm.h
+++ b/firmware/include/comm.h
@@ -9,6 +9,9 @@
 
 #include "config.h"
 
+#define buffer_size 410
+#define WINDOWS_PER_BIT 2
+
 extern uint16_t tx_display_buffer_length;
 
 // Updated in an ISR; volatile prevents the compiler from caching these values in registers
@@ -48,10 +51,6 @@ void _test_set_deliver_fn(void (*fn)(const char*));
 
 // Exposes adc_window_counter so tests can modify/reset it
 uint8_t* _test_get_adc_window_counter();
-
-extern const uint32_t buffer_size;
-
-extern const int WINDOWS_PER_BIT;
 
 extern const uint8_t PACKET_START1;
 extern const uint8_t PACKET_START2;

--- a/firmware/include/comm.h
+++ b/firmware/include/comm.h
@@ -33,18 +33,18 @@ void process_rx_windows();
 #include "goertzel.h"
 
 // Declares a function that returns a pointer to the internal bitstream[] array, which is static in comm.cpp:
-uint8_t* _test_get_bitstream();
+uint8_t* _test_get_window_stream();
 
 // Declares a function that returns a pointer to the internal bit_index variable
-int* _test_get_bit_index();
+int* _test_get_window_index();
+
+// Declares a function that returns a pointer to the internal gs[] array, which holds the Goertzel filter states (used to determine bit values):
+goertzel_state* _test_get_goertzel_state();
 
 char* _test_get_delivered_message();
 
 // Used by tests to verify what message was "delivered" without calling any hardware-dependent code:
 void _test_set_deliver_fn(void (*fn)(const char*));
-
-// Declares a function that returns a pointer to the internal gs[] array, which holds the Goertzel filter states (used to determine bit values):
-goertzel_state* _test_get_goertzel_state();
 
 // Exposes a pointer to adc_window_counter so tests can modify/reset it:
 uint8_t* _test_get_adc_window_counter();

--- a/firmware/include/comm.h
+++ b/firmware/include/comm.h
@@ -1,6 +1,6 @@
 // ==================================================================
 // comm.h
-// Declarations for analog signal transmission, reception, and DSP setup
+// / Declarations for analog signal transmission/reception and DSP (FSK/Goertzel
 // ==================================================================
 #ifndef COMM_H
 #define COMM_H
@@ -11,7 +11,7 @@
 
 extern uint16_t tx_display_buffer_length;
 
-// Since these are updated within an interrupt, made these volatile-qualified to ensure the compiler is reading/writing these directly to/from memory instead of to/from a CPU register with potentially outdated data:
+// Updated in an ISR; volatile prevents the compiler from caching these values in registers
 extern volatile float curr_mag_2kHz;
 extern volatile float curr_mag_2_2kHz;
 extern volatile bool mag_ready;
@@ -32,28 +32,35 @@ void process_rx_windows();
 
 #include "goertzel.h"
 
-// Declares a function that returns a pointer to the internal bitstream[] array, which is static in comm.cpp:
+// Returns a pointer to the internal window_stream[] array (static in comm.cpp)
 uint8_t* _test_get_window_stream();
 
-// Declares a function that returns a pointer to the internal bit_index variable
+// Returns a pointer to the internal window_index variable
 int* _test_get_window_index();
 
-// Declares a function that returns a pointer to the internal gs[] array, which holds the Goertzel filter states (used to determine bit values):
+// Returns a pointer to the internal gs[] array holding Goertzel filter states
 goertzel_state* _test_get_goertzel_state();
 
 char* _test_get_delivered_message();
 
-// Used by tests to verify what message was "delivered" without calling any hardware-dependent code:
+// Used by tests to capture/verify delivered messages without hardware-dependent code
 void _test_set_deliver_fn(void (*fn)(const char*));
 
-// Exposes a pointer to adc_window_counter so tests can modify/reset it:
+// Exposes adc_window_counter so tests can modify/reset it
 uint8_t* _test_get_adc_window_counter();
 
 extern const uint32_t buffer_size;
 
+extern const int WINDOWS_PER_BIT;
+
+extern const uint8_t PACKET_START1;
+extern const uint8_t PACKET_START2;
+extern const uint8_t PACKET_END1;
+extern const uint8_t PACKET_END2;
+
 volatile uint16_t* _test_get_adc_buffer_curr_half();
 
-// Otherwise local functions that only need to be exposed globally for testing:
+// Normally internal functions; exposed only for unit tests
 void adc_buffer_full_interrupt();
 void decode_single_bit_from_adc_window(const uint16_t* samples, size_t size);
 void deliver_message(const char* message);

--- a/firmware/include/comm.h
+++ b/firmware/include/comm.h
@@ -44,9 +44,9 @@ uint8_t* _test_get_adc_window_counter();
 
 extern const uint32_t buffer_size;
 
-uint16_t* _test_get_adc_buffer_half_1();
+uint16_t* _test_get_adc_buffer_prev_half();
 
-volatile uint16_t* _test_get_adc_buffer_half_2();
+volatile uint16_t* _test_get_adc_buffer_curr_half();
 
 uint16_t* _test_get_adc_buffer_full_bit();
 

--- a/firmware/include/comm.h
+++ b/firmware/include/comm.h
@@ -64,7 +64,8 @@ void adc_buffer_full_interrupt();
 void decode_single_bit_from_adc_window(const uint16_t* samples, size_t size);
 void deliver_message(const char* message);
 void get_bit_from_top_frequency();
-void check_for_complete_packet();
+// Returns payload length on success (and fills message, null-terminated); 0 if no complete packet.
+size_t check_for_complete_packet(char* message, size_t message_cap);
 
 #endif // UNIT_TEST
 

--- a/firmware/include/comm.h
+++ b/firmware/include/comm.h
@@ -11,6 +11,11 @@
 
 extern uint16_t tx_display_buffer_length;
 
+// Since these are updated within an interrupt, made these volatile-qualified to ensure the compiler is reading/writing these directly to/from memory instead of to/from a CPU register with potentially outdated data:
+extern volatile float curr_mag_2kHz;
+extern volatile float curr_mag_2_2kHz;
+extern volatile bool mag_ready;
+
 void transmit_message(const char* message_to_transmit, const tx_parameters_t* tx_parameters);
 
 void setup_receiver();

--- a/firmware/include/comm.h
+++ b/firmware/include/comm.h
@@ -44,18 +44,14 @@ uint8_t* _test_get_adc_window_counter();
 
 extern const uint32_t buffer_size;
 
-uint16_t* _test_get_adc_buffer_prev_half();
-
 volatile uint16_t* _test_get_adc_buffer_curr_half();
-
-uint16_t* _test_get_adc_buffer_full_bit();
 
 // Otherwise local functions that only need to be exposed globally for testing:
 void adc_buffer_full_interrupt();
-void decode_single_bit_from_adc_window();
+void decode_single_bit_from_adc_window(const uint16_t* samples, size_t size);
 void deliver_message(const char* message);
 void get_bit_from_top_frequency();
-void parse_message();
+void check_for_complete_packet();
 
 #endif // UNIT_TEST
 

--- a/firmware/include/comm.h
+++ b/firmware/include/comm.h
@@ -22,6 +22,8 @@ void setup_receiver();
 
 void setup_transmitter();
 
+void process_rx_windows();
+
 // ------------------------------------------------------------------
 // Testing Accessors
 // ------------------------------------------------------------------

--- a/firmware/include/comm.h
+++ b/firmware/include/comm.h
@@ -58,7 +58,7 @@ extern const uint8_t PACKET_START2;
 extern const uint8_t PACKET_END1;
 extern const uint8_t PACKET_END2;
 
-volatile uint16_t* _test_get_adc_buffer_curr_half();
+volatile uint16_t* _test_get_adc_dma_window();
 
 // Normally internal functions; exposed only for unit tests
 void adc_buffer_full_interrupt();

--- a/firmware/include/config.h
+++ b/firmware/include/config.h
@@ -8,6 +8,11 @@
 #include <time.h>
 
 //----------------------------------------
+// Screen Behavior Configuration
+//----------------------------------------
+#define SCREEN_TIMEOUT_MS 20000
+
+//----------------------------------------
 // Chat Display Configuration
 //----------------------------------------
 #define CHAT_BOX_LINE_PADDING       11      // Extra vertical space between chat lines

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -18,4 +18,5 @@ lib_deps =
   kurte/ILI9341_t3n
 build_flags = -DUNIT_TEST -Itest
 test_build_src = true
-; run using: pio test -e teensy40_test
+; run using:
+; pio test -e teensy40_test

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -6,7 +6,9 @@ board = teensy40
 framework = arduino
 lib_deps =
   kurte/ILI9341_t3n
-; run using: pio run -e teensy40 -t upload
+; run using:
+; pio run -e teensy40 -t upload
+; pio device monitor
 
 [env:teensy40_test]
 platform = teensy

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -417,6 +417,8 @@ void get_bit_from_top_frequency() {
   uint8_t bit = (mag_2_2kHz > mag_2kHz) ? 1 : 0;
   if (bit_index < MAX_BITS) {
     bitstream[bit_index++] = bit;
+    Serial.print("bit: ");
+    Serial.println(bit);
   }
 }
 

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -1,6 +1,6 @@
 // ==================================================================
 // comm.cpp
-// Handles analog signal transmission, reception, and DSP setup
+// Handles analog FSK transmission, reception, and DSP (Goertzel)
 // ==================================================================
 #include <Arduino.h> // for digitalWriteFast
 #include <ADC.h>
@@ -63,20 +63,19 @@ static volatile uint8_t rx_queue_read_index = 0;
 static volatile uint8_t rx_queue_count = 0;
 static volatile bool rx_queue_overrun = false;
 
-// Holds one pair of Goertzel magnitudes:
-// Every time G runs, it gives a magnitude for each of the 2 frequencies we're checking
+// Holds one pair of Goertzel magnitudes (2.0 kHz + 2.2 kHz)
 struct goertzel_output_t {
   float mag_2kHz;
   float mag_2_2kHz;
 };
 
-// Stores recent Goertzel magnitudes for each bit window in a circular buffer:
+// Stores recent Goertzel magnitudes in a circular buffer
 static const size_t G_HISTORY_LEN = 16;
 static goertzel_output_t goertzel_history_circ_buffer[G_HISTORY_LEN];
 static size_t goertzel_history_circ_buffer_index = 0;
 
-// If k = the min # of bits that need to be seen in order to identify the bit boundaries in relation to the sampling window,
-// then 2k + = the min # windows (Goertzel outputs) that need to be seen
+// If k = min bits needed to identify bit boundaries relative to sampling windows,
+// then 2k + 1 = min windows (Goertzel outputs) that need to be seen
 // Since k = 3, 2k + 1 = 7
 static const size_t ALIGNMENT_IDENTIFYING_G_OUTPUTS = 7;
 static goertzel_output_t window_history[ALIGNMENT_IDENTIFYING_G_OUTPUTS];
@@ -103,26 +102,24 @@ DMAChannel dma_ch1;
 // DMAMEM places adc_buffer_curr_half in RAM2 (OCRAM):
 DMAMEM static volatile uint16_t __attribute__((aligned(32))) adc_buffer_curr_half[buffer_size];
 
-// Gets incremented every time decode_single_bit_from_adc_window() runs, and decoding
-// only happens when adc_window_counter % SCAN_CHAIN_LENGTH == 0:
+// Gets incremented every time decode_single_bit_from_adc_window() runs
 static uint8_t adc_window_counter = 0;
 
-// An array that will store state for the Goertzel algo - each goertzel_state obj
-// holds data to compute G algo for that frequency:
+// Goertzel filter state (one per target frequency)
 static const uint8_t gs_len = 2;   // only 2 bins: 2.0 kHz and 2.2 kHz
 goertzel_state gs[gs_len];
 
 // Charge amplifier gain:
 static const int adg728_i2c_address = 76;
 
-// For get_bit_from_top_frequency:
+// Bitstream buffer (window-level bit guesses)
 static const int MAX_BITS = 256;
 static uint8_t window_stream[MAX_BITS * WINDOWS_PER_BIT];
 static int window_index = 0;
 static const float MAGNITUDE_THRESHOLD = 5.0f; // TODO: adjust as needed based on testing
 
-// Packet framing bytes:
-// Note: Using two-byte delimiters is more reliable than using one
+// Packet framing bytes (2-byte header + 2-byte footer)
+// Note: Two-byte delimiters reduce false positives vs single-byte framing
 #ifdef UNIT_TEST
 const uint8_t PACKET_START1 = 0x01;
 const uint8_t PACKET_START2 = 0x02;
@@ -136,7 +133,7 @@ static const uint8_t PACKET_END2   = 0x04;
 #endif
 
 // For preamble:
-static const uint16_t PREAMBLE_BITS = 35; // unit is bits. 35 bits * 10 ms = 350 ms total preamble length
+static const uint16_t PREAMBLE_BITS = 35; // bits; duration depends on tx_parameters->usec_per_bit
 
 // ------------------------------------------------------------------
 // Functions
@@ -150,7 +147,7 @@ static const uint16_t PREAMBLE_BITS = 35; // unit is bits. 35 bits * 10 ms = 350
  */
 void write_to_dac(uint8_t address, uint16_t value) {
   uint8_t buf[3];
-  // Bits 1 and 2 must be 0 to write:
+  // SPI frame: bits 1–2 must be 0 for write
   buf[0] = (address << 3);
   buf[1] = (uint8_t)(value >> 8);
   buf[2] = (uint8_t)value;
@@ -167,7 +164,7 @@ void write_to_dac(uint8_t address, uint16_t value) {
  * then drives the DAC sample-by-sample for the full bit duration.
  */
 static inline void transmit_bit(uint8_t bit, const tx_parameters_t* tx_parameters) {
-  // w is the angular frequency, wherein w = 2 * pi * freq
+  // w is radians per microsecond: w = 2πf / 1e6 (f in Hz)
   const float w = (bit ? (2 * PI * tx_parameters->freq_high / 1e6)
                        : (2 * PI * tx_parameters->freq_low /  1e6));
   const unsigned long bit_start_time = micros();
@@ -204,7 +201,7 @@ static inline void transmit_preamble(const tx_parameters_t* tx_parameters) {
 /**
  * FSK transmitter: for each char, emit its 8 bits MSB‑first as tones.
  * Uses freq_low for 0 and freq_high for 1; each bit lasts usec_per_bit microseconds.
- * The sine is generated with w = 2πf and time in microseconds, so f is in Hz and time is µs.
+ * The sine uses w = 2πf/1e6 with time in µs (f in Hz).
  */
 void transmit_message(const char* message_to_transmit, const tx_parameters_t* tx_parameters) {
   transmit_preamble(tx_parameters);
@@ -216,7 +213,7 @@ void transmit_message(const char* message_to_transmit, const tx_parameters_t* tx
     // Translates each of char's 8 bits into a corresponding frequency starting with msb:
     for (int j = 7; j >= 0; j--) {
       int bit = (letter >> j) & 1;
-      // w is the angular frequency, wherein w = 2 * pi * f
+      // w is radians per microsecond: w = 2πf / 1e6 (f in Hz)
       float w = (bit) ? (2 * PI * tx_parameters->freq_high / 1e6)
                       : (2 * PI * tx_parameters->freq_low / 1e6);
       // Start time for the current bit period:
@@ -310,8 +307,8 @@ void deliver_message(const char* message) {
 }
 
 /**
- * Computes the average combined magnitude (2.0 kHz + 2.2 kHz)
- * over the most recent `window_count` entries in window_history.
+ * Computes average combined magnitude over `window_count` entries starting at window_history_index
+ * (not strictly “most recent”).
  */
 static float average_window_magnitude(size_t window_count) {
   float sum = 0.0f;
@@ -541,8 +538,7 @@ void for_each_goertzel_state(void (*one_param_fn)(goertzel_state*), void (*two_p
 }
 
 /**
- * Processes one ADC window at bit-aligned intervals:
- * runs Goertzel, extracts a bit, appends it to the window_stream, checks for a complete packet, then resets Goertzel state.
+ * Processes one ADC sample window (5 ms): runs Goertzel, attempts bit extraction, and packet detection
  */
 void decode_single_bit_from_adc_window(const uint16_t* samples, size_t size) {
   adc_window_counter++;
@@ -572,11 +568,9 @@ void decode_single_bit_from_adc_window(const uint16_t* samples, size_t size) {
 }
 
 /**
- * Called when DMA fills the ADC buffer. Clears the DMA interrupt, invalidates CPU cache for the DMA buffer,
- * passes the fresh samples to the decoder, then re-enables DMA.
- * DMA writes to RAM2 -> decode_single_bit_from_adc_window reads from RAM2.
- * Each ADC buffer ≈ 5 ms (410 samples @ 81.92 kHz). If SCAN_CHAIN_LENGTH == 2 and TX bit period is ~10 ms,
- * two buffers correspond to one bit period, and adc_buffer_full_interrupt() fires every 5 ms.
+ * ISR on DMA completion: clears interrupt, invalidates cache, copies samples into rx queue, re-enables DMA.
+ * DMA writes to RAM2; ISR copies samples into RAM1 rx queue, and decoding reads from RAM1
+ * Each ADC buffer ≈ 5 ms (410 samples @ 81.92 kHz); ISR fires every buffer completion (~5 ms).
  */
 void adc_buffer_full_interrupt() {
   // Clears the DMA interrupt flag so it's ready for the next transfer:
@@ -631,10 +625,6 @@ void process_rx_windows() {
  * sets the gain on the charge amplifier, sets up DMA channel for ADC to send data to buffer.
  */
 void setup_receiver() {
-  // For pulse_begin() / pulse_end():
-  pinMode(1, OUTPUT);
-  digitalWriteFast(1, LOW);
-
   // Sets readPin_adc_0_pin as the input pin for ADC sampling:
   pinMode(readPin_adc_0_pin, INPUT);
 

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -437,11 +437,14 @@ void get_bit_from_top_frequency() {
 }
 
 /**
- * Reassembles bytes MSB‑first from window_stream[], searches for 2‑byte header/footer,
- * copies the payload to a C‑string, delivers it, then resets the bit buffer.
+ * Reassembles bytes MSB‑first from window_stream[], searches for 2‑byte header/footer.
+ * On success copies the payload into message[], null-terminates, resets the bit buffer,
+ * and returns the payload length. Returns 0 if no valid packet found.
  * Header: PACKET_START1, PACKET_START2. Footer: PACKET_END1, PACKET_END2.
  */
- void check_for_complete_packet() {
+size_t check_for_complete_packet(char* message, size_t message_cap) {
+  if (message == nullptr || message_cap == 0) return 0;
+
   // Buffer to hold reconstructed bytes from the window_stream:
   static char decoded_bytes[MAX_PACKET_SIZE];
 
@@ -470,7 +473,7 @@ void get_bit_from_top_frequency() {
         break;
       }
     }
-    if (start == -1) continue;   // <- was return
+    if (start == -1) continue;
 
     // Scans for packet end (footer):
     int end = -1;
@@ -481,27 +484,21 @@ void get_bit_from_top_frequency() {
         break;
       }
     }
-    if (end == -1) continue;     // <- was return
+    if (end == -1) continue;
 
-    int msg_len = end - start;
-    if (msg_len <= 0 || msg_len >= MAX_TEXT_LENGTH) {
+    size_t msg_len = (size_t)(end - start);
+    if (msg_len == 0 || msg_len >= MAX_TEXT_LENGTH || msg_len >= message_cap) {
       window_index = 0;
-      return;
+      return 0;
     }
 
-    char message[MAX_TEXT_LENGTH];
     memcpy(message, &decoded_bytes[start], msg_len);
     message[msg_len] = '\0';
 
-    // Adds message to chat history and displays it:
-    deliver_message(message);
-
-    // Resets bit buffer:
     window_index = 0;
-
-    return; // success case
+    return msg_len;
   }
-  // If here: tried all offsets, nothing valid found
+  return 0;
 }
 
 /**
@@ -547,7 +544,10 @@ void decode_single_bit_from_adc_window(const uint16_t* samples, size_t size) {
   }
 
   get_bit_from_top_frequency();
-  check_for_complete_packet();
+  char msg_buf[MAX_TEXT_LENGTH];
+  if (check_for_complete_packet(msg_buf, sizeof(msg_buf)) > 0) {
+    deliver_message(msg_buf);
+  }
 
   // Resets internal Goertzel state (not y_re/y_im):
   for_each_goertzel_state(reset_goertzel, NULL, -1);
@@ -597,7 +597,10 @@ void process_rx_windows() {
 
     if (++scan_div >= 16) {
       scan_div = 0;
-      check_for_complete_packet();
+      char msg_buf[MAX_TEXT_LENGTH];
+      if (check_for_complete_packet(msg_buf, sizeof(msg_buf)) > 0) {
+        deliver_message(msg_buf);
+      }
     }
   }
 }

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -29,7 +29,7 @@ static void (*deliver_fn_override)(const char*) = nullptr;
 // ------------------------------------------------------------------
 
 /*
-  adc_buffer_half_2 is filled by the DMA and declared with DMAMEM and __attribute__((aligned(32)))
+  adc_buffer_curr_half is filled by the DMA and declared with DMAMEM and __attribute__((aligned(32)))
   to place it in RAM2 (OCRAM), which is cacheable and requires manual cache management.
 
   RAM1 = DTCM (Tightly Coupled Memory) --> Not cacheable. Always in sync.
@@ -38,12 +38,12 @@ static void (*deliver_fn_override)(const char*) = nullptr;
   which requires manual cache management: arm_dcache_flush() pushes CPU cache changes to RAM2;
   arm_dcache_delete() discards cache so the CPU reads fresh data from RAM2.
 
-  adc_buffer_half_1 is filled by the CPU using memcpy() and lives in regular (uncached) RAM1.
+  adc_buffer_prev_half is filled by the CPU using memcpy() and lives in regular (uncached) RAM1.
 
   adc_buffer_full_bit is the concatenated buffer (half_1 + half_2) that gets analyzed.
 */
 
-// Defines the number of ADC samples collected into a buffer (adc_buffer_half_2) every time the DMA completes a transfer
+// Defines the number of ADC samples collected into a buffer (adc_buffer_curr_half) every time the DMA completes a transfer
 // Number samples collected per ADC window (buffer_size) = adc_sampling_rate * bit period = 81920 * 5 ms = 410 samples
 #ifdef UNIT_TEST
 const uint32_t buffer_size = 410;
@@ -51,12 +51,12 @@ const uint32_t buffer_size = 410;
 static const uint32_t buffer_size = 410;
 #endif
 
-// Holds 5 ms ADC window chunk that was filled before the currrent (adc_buffer_half_2):
-uint16_t adc_buffer_half_1[buffer_size];
+// Holds 5 ms ADC window chunk that was filled before the currrent (adc_buffer_curr_half):
+uint16_t adc_buffer_prev_half[buffer_size];
 
-// adc_buffer_half_1 is considered valid when it holds a full previous DMA buffer,
-// and therefore ready to pair with the current buffer (adc_buffer_half_2) for decoding:
-bool buffer_half_1_is_valid = false;
+// adc_buffer_prev_half is considered valid when it holds a full previous DMA buffer,
+// and therefore ready to pair with the current buffer (adc_buffer_curr_half) for decoding:
+bool prev_buffer_half_is_valid = false;
 
 // ADC will sample at freq of 81.92 kHz:
 static const uint32_t adc_sampling_rate = 81920;
@@ -67,9 +67,9 @@ uint16_t tx_display_buffer_length = 0;
 ADC *adc = new ADC();
 DMAChannel dma_ch1;
 
-// Creates second half of buffer that comprises one bit period when combined with adc_buffer_half_1, and
-// DMAMEM places adc_buffer_half_2 in RAM2 (OCRAM):
-DMAMEM static volatile uint16_t __attribute__((aligned(32))) adc_buffer_half_2[buffer_size];
+// Creates second half of buffer that comprises one bit period when combined with adc_buffer_prev_half, and
+// DMAMEM places adc_buffer_curr_half in RAM2 (OCRAM):
+DMAMEM static volatile uint16_t __attribute__((aligned(32))) adc_buffer_curr_half[buffer_size];
 uint16_t adc_buffer_full_bit[buffer_size * 2];
 
 // Gets incremented every time decode_single_bit_from_adc_window() runs, and decoding
@@ -197,12 +197,12 @@ void setup_transmitter() {
 void deliver_message(const char* message) {
   // If a test override is set, this will call it instead of performing normal delivery logic.
   // Allows unit tests to capture or mock delivery without triggering hardware-dependent code:
-#ifdef UNIT_TEST
+  #ifdef UNIT_TEST
   if (deliver_fn_override) {
     deliver_fn_override(message);
     return;
   }
-#endif
+  #endif
 
   size_t len = strlen(message);
 
@@ -362,21 +362,21 @@ void adc_buffer_full_interrupt() {
   // Clears the DMA interrupt flag so it's ready for the next transfer:
   dma_ch1.clearInterrupt();
 
-  if (buffer_half_1_is_valid) {
+  if (prev_buffer_half_is_valid) {
     // Combines prev + current into adc_buffer_full_bit:
-    memcpy(adc_buffer_full_bit, adc_buffer_half_1, sizeof(adc_buffer_half_1));
-    memcpy(adc_buffer_full_bit + buffer_size, (const void*)adc_buffer_half_2, sizeof(adc_buffer_half_2));
+    memcpy(adc_buffer_full_bit, adc_buffer_prev_half, sizeof(adc_buffer_prev_half));
+    memcpy(adc_buffer_full_bit + buffer_size, (const void*)adc_buffer_curr_half, sizeof(adc_buffer_curr_half));
   } else {
     // Not ready to decode yet, just store current into prev and return:
-    memcpy(adc_buffer_half_1, (const void*)adc_buffer_half_2, sizeof(adc_buffer_half_2));
-    buffer_half_1_is_valid = true;
+    memcpy(adc_buffer_prev_half, (const void*)adc_buffer_curr_half, sizeof(adc_buffer_curr_half));
+    prev_buffer_half_is_valid = true;
     dma_ch1.enable();
     return;
   }
 
-  // Invalidates CPU cache for adc_buffer_half_2 to ensure CPU sees the latest data written by DMA (RAM2 is cacheable):
-  if ((uint32_t)adc_buffer_half_2 >= 0x20200000u) {
-    arm_dcache_delete((void *)adc_buffer_half_2, sizeof(adc_buffer_half_2));
+  // Invalidates CPU cache for adc_buffer_curr_half to ensure CPU sees the latest data written by DMA (RAM2 is cacheable):
+  if ((uint32_t)adc_buffer_curr_half >= 0x20200000u) {
+    arm_dcache_delete((void *)adc_buffer_curr_half, sizeof(adc_buffer_curr_half));
   }
 
   // Re-enables the DMA channel for next read:
@@ -384,7 +384,7 @@ void adc_buffer_full_interrupt() {
 
   // Uses Goertzel algorithm to analyze the frequency content of a series of ADC samples:
   decode_single_bit_from_adc_window();
-  buffer_half_1_is_valid = false;
+  prev_buffer_half_is_valid = false;
 }
 
 /**
@@ -408,7 +408,7 @@ void setup_receiver() {
   adc->adc0->setConversionSpeed(ADC_CONVERSION_SPEED::HIGH_SPEED);
   //adc->adc0->setSamplingSpeed(ADC_SAMPLING_SPEED::HIGH_SPEED);
 
-  // Configures DMA to transfer ADC samples into adc_buffer_half_2:
+  // Configures DMA to transfer ADC samples into adc_buffer_curr_half:
   // Note: The following line may raise a compiler warning because type-punning ADC1_R0 here violates strict aliasing rules, but can be safely ignored
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wstrict-aliasing"
@@ -416,7 +416,7 @@ void setup_receiver() {
   #pragma GCC diagnostic pop
 
   // Each time you sample from ADC you get 2 bytes, so that's why we're using buffer_size * 2:
-  dma_ch1.destinationBuffer((uint16_t *)adc_buffer_half_2, buffer_size);
+  dma_ch1.destinationBuffer((uint16_t *)adc_buffer_curr_half, buffer_size);
   dma_ch1.interruptAtCompletion();
   dma_ch1.disableOnCompletion();
 
@@ -471,13 +471,13 @@ uint8_t* _test_get_adc_window_counter() {
   return &adc_window_counter;
 }
 
-uint16_t* _test_get_adc_buffer_half_1() {
-  return adc_buffer_half_1;
+uint16_t* _test_get_adc_buffer_prev_half() {
+  return adc_buffer_prev_half;
 }
 
-// Returns a pointer to adc_buffer_half_2 so tests can fill it with mock ADC data - volatile because it's the DMA destination:
-volatile uint16_t* _test_get_adc_buffer_half_2() {
-  return adc_buffer_half_2;
+// Returns a pointer to adc_buffer_curr_half so tests can fill it with mock ADC data - volatile because it's the DMA destination:
+volatile uint16_t* _test_get_adc_buffer_curr_half() {
+  return adc_buffer_curr_half;
 }
 
 // Returns a pointer to adc_buffer_full_bit	so tests can inspect or clear copied ADC data:

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -139,6 +139,10 @@ void write_to_dac(uint8_t address, uint16_t value) {
   SPI.endTransaction();
 }
 
+/**
+ * Outputs one bit as a sine wave: picks high/low frequency based on bit value,
+ * then drives the DAC sample-by-sample for the full bit duration.
+ */
 static inline void transmit_bit(uint8_t bit, const tx_parameters_t* tx_parameters) {
   // w is the angular frequency, wherein w = 2 * pi * freq
   const float w = (bit ? (2 * PI * tx_parameters->freq_high / 1e6)
@@ -158,6 +162,10 @@ static inline void transmit_bit(uint8_t bit, const tx_parameters_t* tx_parameter
   }
 }
 
+/**
+ * Sends the preamble sequence (alternating 1/0 bits for PREAMBLE_BITS length)
+ * to help the receiver establish timing and alignment.
+ */
 static inline void transmit_preamble(const tx_parameters_t* tx_parameters) {
   // Arbitrarily choosing to start the preamble with a 1 instead of a 0:
   uint8_t curr_bit = 1;
@@ -279,6 +287,10 @@ void deliver_message(const char* message) {
   display_chat_history(state);
 }
 
+/**
+ * Computes the average combined magnitude (2.0 kHz + 2.2 kHz)
+ * over the most recent `window_count` entries in window_history.
+ */
 static float average_window_magnitude(size_t window_count) {
   float sum = 0.0f;
   for (size_t i = 0; i < window_count; i++) {
@@ -288,12 +300,22 @@ static float average_window_magnitude(size_t window_count) {
   return sum / window_count;
 }
 
+/**
+ * Returns 0 if 2.0 kHz is stronger, 1 if 2.2 kHz is stronger,
+ * or 255 if magnitudes are equal (ambiguous).
+ */
 static inline uint8_t determine_bit(const goertzel_output_t* g_ouput) {
   if (g_ouput->mag_2_2kHz > g_ouput->mag_2kHz) return 1;
   if (g_ouput->mag_2_2kHz < g_ouput->mag_2kHz) return 0;
   return 255; // out of range value (uint8_t ~ 0-255) that can be used to check for error case
 }
 
+/**
+ * Uses the rolling window_history to decide bit boundaries.
+ * Checks both possible phases; if at least 3 alternating 0/1 pairs
+ * are found and average magnitude is above threshold,
+ * sets bit_alignment_phase and marks boundaries as known.
+ */
 static void find_bit_boundaries(void) {
   if (!have_enough_windows || bit_boundaries_are_known) return;
 
@@ -318,7 +340,6 @@ static void find_bit_boundaries(void) {
       if (b0 != b1) {
         alternating_pairs++;
       }
-
     }
 
     // If we saw 3 alternating pairs, assume we found the correct bit boundaries
@@ -327,7 +348,6 @@ static void find_bit_boundaries(void) {
       bit_boundaries_are_known = true;
       return; // stop searching once locked
     }
-
   }
 }
 

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -456,7 +456,9 @@ void get_bit_from_top_frequency() {
         uint8_t bit = window_stream[i + WINDOWS_PER_BIT * b];
         byte = (byte << 1) | bit;
       }
-      if (byte_count < MAX_PACKET_SIZE) decoded_bytes[byte_count++] = (char)byte;
+      if (byte_count < MAX_PACKET_SIZE) {
+        decoded_bytes[byte_count++] = (char)byte;
+      }
     }
 
     // Scans for packet start (header):
@@ -568,7 +570,7 @@ void adc_buffer_full_interrupt() {
     memcpy(rx_win_q[rx_queue_write_index],
            (const void*)adc_dma_window,
            sizeof(rx_win_q[0]));
-    rx_queue_write_index = (rx_queue_write_index + 1) & 1;
+    rx_queue_write_index = (rx_queue_write_index + 1) % 2;
     rx_queue_count++;
   }
 
@@ -584,12 +586,10 @@ void process_rx_windows() {
   static uint8_t scan_div = 0;
 
   while (true) {
-    uint8_t slot;
-
     noInterrupts();
     if (rx_queue_count == 0) { interrupts(); break; }
-    slot = rx_queue_read_index;
-    rx_queue_read_index = (rx_queue_read_index + 1) & 1;
+    uint8_t slot = rx_queue_read_index;
+    rx_queue_read_index = (rx_queue_read_index + 1) % 2;
     rx_queue_count--;
     interrupts();
 

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -47,7 +47,12 @@ const uint32_t buffer_size = 410;
 static const uint32_t buffer_size = 410;
 #endif
 
+#ifdef UNIT_TEST
+const int WINDOWS_PER_BIT = 2;
+#else
 static const int WINDOWS_PER_BIT = 2;
+#endif
+
 static const float MIN_TONE_MAGNITUDE = 1.0f; // Update value later with more testing
 
 // 2-window queue in RAM1 (DTCM). Each window is one 5ms window (410 samples).
@@ -118,10 +123,17 @@ static const float MAGNITUDE_THRESHOLD = 5.0f; // TODO: adjust as needed based o
 
 // Packet framing bytes:
 // Note: Using two-byte delimiters is more reliable than using one
+#ifdef UNIT_TEST
+const uint8_t PACKET_START1 = 0x01;
+const uint8_t PACKET_START2 = 0x02;
+const uint8_t PACKET_END1   = 0x03;
+const uint8_t PACKET_END2   = 0x04;
+#else
 static const uint8_t PACKET_START1 = 0x01;
 static const uint8_t PACKET_START2 = 0x02;
 static const uint8_t PACKET_END1   = 0x03;
 static const uint8_t PACKET_END2   = 0x04;
+#endif
 
 // For preamble:
 static const uint16_t PREAMBLE_BITS = 35; // unit is bits. 35 bits * 10 ms = 350 ms total preamble length
@@ -452,12 +464,12 @@ void get_bit_from_top_frequency() {
   // Buffer to hold reconstructed bytes from the window_stream:
   static char decoded_bytes[MAX_PACKET_SIZE];
 
-  for (int off = 0; off < 16; off++) {
+  for (int offset = 0; offset < 16; offset++) {
     // Tracks how many full bytes have been reconstructed from the incoming window_stream[]:
     int byte_count = 0;
 
     // decode bytes starting at this offset
-    for (int i = off; i + 15 < window_index; i += 16) {
+    for (int i = offset; i + 15 < window_index; i += 16) {
       uint8_t byte = 0;
       for (int b = 0; b < 8; b++) {
         uint8_t bit = window_stream[i + WINDOWS_PER_BIT * b];
@@ -489,7 +501,10 @@ void get_bit_from_top_frequency() {
     if (end == -1) continue;     // <- was return
 
     int msg_len = end - start;
-    if (msg_len <= 0 || msg_len >= MAX_TEXT_LENGTH) continue;
+    if (msg_len <= 0 || msg_len >= MAX_TEXT_LENGTH) {
+      window_index = 0;
+      return;
+    }
 
     char message[MAX_TEXT_LENGTH];
     memcpy(message, &decoded_bytes[start], msg_len);

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -58,7 +58,8 @@ typedef struct _goertzel_output {
   float mag_2_2kHz;
 } goertzel_output_t;
 
-// Long history: optional analysis/plotting. Short rolling window below is used for bit-boundary detection.
+// Single circular buffer for Goertzel magnitudes: used for analysis/plotting and for bit-boundary
+// detection (last ALIGNMENT_IDENTIFYING_G_OUTPUTS entries).
 static const size_t G_HISTORY_LEN = 16;
 static goertzel_output_t goertzel_history_circ_buffer[G_HISTORY_LEN];
 static size_t goertzel_history_circ_buffer_index = 0;
@@ -66,8 +67,6 @@ static size_t goertzel_history_circ_buffer_index = 0;
 // If k = min bits needed to identify bit boundaries relative to sampling windows,
 // then 2k + 1 = min windows (Goertzel outputs) that need to be seen. Since k = 3, 2k + 1 = 7.
 static const size_t ALIGNMENT_IDENTIFYING_G_OUTPUTS = 7;
-static goertzel_output_t window_history[ALIGNMENT_IDENTIFYING_G_OUTPUTS];
-static size_t window_history_index = 0;
 static bool bit_boundaries_are_known = false;
 static uint8_t bit_alignment_phase = 0; // 0 = even windows, 1 = odd windows
 static bool have_enough_windows = false;
@@ -283,10 +282,10 @@ void deliver_message(const char* message) {
  * Computes average combined magnitude over `window_count` entries in the circular history starting at `history_index`
  * (not strictly “most recent”).
  */
-static float average_window_magnitude(size_t window_count, const goertzel_output_t* window_hist, size_t history_index) {
+static float average_window_magnitude(size_t window_count, const goertzel_output_t* window_hist, size_t history_len, size_t history_index) {
   float sum = 0.0f;
   for (size_t i = 0; i < window_count; i++) {
-    size_t index = (history_index + i) % ALIGNMENT_IDENTIFYING_G_OUTPUTS;
+    size_t index = (history_index + i) % history_len;
     sum += window_hist[index].mag_2kHz + window_hist[index].mag_2_2kHz;
   }
   return sum / window_count;
@@ -303,7 +302,7 @@ static inline uint8_t determine_bit(const goertzel_output_t* g_ouput) {
 }
 
 /**
- * Uses the rolling window_history to decide bit boundaries.
+ * Uses the last ALIGNMENT_IDENTIFYING_G_OUTPUTS entries of the Goertzel history to decide bit boundaries.
  * Checks both possible phases; if at least 3 alternating 0/1 pairs
  * are found and average magnitude is above threshold,
  * sets bit_alignment_phase and marks boundaries as known.
@@ -311,8 +310,10 @@ static inline uint8_t determine_bit(const goertzel_output_t* g_ouput) {
 static void find_bit_boundaries(void) {
   if (!have_enough_windows || bit_boundaries_are_known) return;
 
-  // Basically just deciding here the signal is viable if the average magnitude is above some predetermined threshold
-  float avg_mag = average_window_magnitude(ALIGNMENT_IDENTIFYING_G_OUTPUTS, window_history, window_history_index);
+  // Base index for the "last 7" entries in the circular buffer
+  const size_t base = (goertzel_history_circ_buffer_index + G_HISTORY_LEN - ALIGNMENT_IDENTIFYING_G_OUTPUTS) % G_HISTORY_LEN;
+
+  float avg_mag = average_window_magnitude(ALIGNMENT_IDENTIFYING_G_OUTPUTS, goertzel_history_circ_buffer, G_HISTORY_LEN, base);
   if (avg_mag < MAGNITUDE_THRESHOLD) return;
 
   // Outer loop tries both phases
@@ -321,11 +322,11 @@ static void find_bit_boundaries(void) {
 
     // Inner loop tries pairs of windows for each phase
     for (size_t i = 0; i + 1 < ALIGNMENT_IDENTIFYING_G_OUTPUTS; i += 2) {
-      size_t idx0 = (window_history_index + i + phase) % ALIGNMENT_IDENTIFYING_G_OUTPUTS;
-      size_t idx1 = (window_history_index + i + 1 + phase) % ALIGNMENT_IDENTIFYING_G_OUTPUTS;
+      size_t idx0 = (base + i + phase) % G_HISTORY_LEN;
+      size_t idx1 = (base + i + 1 + phase) % G_HISTORY_LEN;
 
-      uint8_t b0 = determine_bit(&window_history[idx0]);
-      uint8_t b1 = determine_bit(&window_history[idx1]);
+      uint8_t b0 = determine_bit(&goertzel_history_circ_buffer[idx0]);
+      uint8_t b1 = determine_bit(&goertzel_history_circ_buffer[idx1]);
 
       // Skip if either window was ambiguous (tie → 255)
       if (b0 == 255 || b1 == 255) continue;
@@ -343,6 +344,7 @@ static void find_bit_boundaries(void) {
   }
 }
 
+// TODO (future refactor): bundle receiver state into a struct and pass to reset_receiver_state(&state).
 static void reset_receiver_state() {
   noInterrupts();
   rx_queue_write_index = rx_queue_read_index = rx_queue_count = 0;
@@ -356,7 +358,6 @@ static void reset_receiver_state() {
   windows_collected = 0;
   consecutive_weak_windows = 0;
 
-  window_history_index = 0;
   goertzel_history_circ_buffer_index = 0;
 }
 
@@ -370,13 +371,9 @@ void get_bit_from_top_frequency() {
   float mag_2kHz = sqrtf(powf(gs[0].y_re, 2) + powf(gs[0].y_im, 2));
   float mag_2_2kHz = sqrtf(powf(gs[1].y_re, 2) + powf(gs[1].y_im, 2));
 
-  // Stores magnitudes in circ buffer for later analysis:
+  // Single circular buffer: stores magnitudes for analysis and for bit-boundary detection (last 7 used).
   goertzel_history_circ_buffer[goertzel_history_circ_buffer_index] = { mag_2kHz, mag_2_2kHz };
   goertzel_history_circ_buffer_index = (goertzel_history_circ_buffer_index + 1) % G_HISTORY_LEN;
-
-  // Keeps a short rolling history used for boundary detection:
-  window_history[window_history_index] = { mag_2kHz, mag_2_2kHz };
-  window_history_index = (window_history_index + 1) % ALIGNMENT_IDENTIFYING_G_OUTPUTS;
 
   // Keep counting windows until we’ve seen enough to attempt boundary detection:
   if (!have_enough_windows) {
@@ -386,7 +383,7 @@ void get_bit_from_top_frequency() {
     }
   }
 
-  // Use the rolling window_history to determine where bit edges fall (sets bit_boundaries_are_known/bit_alignment_phase):
+  // Use last 7 entries of Goertzel history to determine bit edges (sets bit_boundaries_are_known/bit_alignment_phase):
   find_bit_boundaries();
 
   // If boundaries aren’t established yet, stop here (only magnitudes logged this window):
@@ -394,8 +391,9 @@ void get_bit_from_top_frequency() {
     return;
   }
 
-  // Boundaries are known → keep monitoring average strength:
-  float avg_mag_lock = average_window_magnitude(ALIGNMENT_IDENTIFYING_G_OUTPUTS, window_history, window_history_index);
+  // Boundaries are known → keep monitoring average strength (last 7 entries of circ buffer):
+  const size_t base = (goertzel_history_circ_buffer_index + G_HISTORY_LEN - ALIGNMENT_IDENTIFYING_G_OUTPUTS) % G_HISTORY_LEN;
+  float avg_mag_lock = average_window_magnitude(ALIGNMENT_IDENTIFYING_G_OUTPUTS, goertzel_history_circ_buffer, G_HISTORY_LEN, base);
   if (avg_mag_lock < MAGNITUDE_THRESHOLD) {
     if (++consecutive_weak_windows >= MAX_WEAK_WINDOWS) {
       // Signal stayed weak too long → reset state:

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -37,26 +37,43 @@ static void (*deliver_fn_override)(const char*) = nullptr;
   RAM2 = OCRAM (what DMAMEM uses) --> Cacheable. Can get out of sync with the Teensy CPU’s data cache,
   which requires manual cache management: arm_dcache_flush() pushes CPU cache changes to RAM2;
   arm_dcache_delete() discards cache so the CPU reads fresh data from RAM2.
-
-  adc_buffer_prev_half is filled by the CPU using memcpy() and lives in regular (uncached) RAM1.
-
-  adc_buffer_full_bit is the concatenated buffer (half_1 + half_2) that gets analyzed.
 */
 
-// Defines the number of ADC samples collected into a buffer (adc_buffer_curr_half) every time the DMA completes a transfer
-// Number samples collected per ADC window (buffer_size) = adc_sampling_rate * bit period = 81920 * 5 ms = 410 samples
+// Number of ADC samples per DMA transfer into adc_buffer_curr_half.
+// Samples per window (buffer_size) = adc_sampling_rate * window_duration = 81,920 * 5 ms = 410 samples.
 #ifdef UNIT_TEST
 const uint32_t buffer_size = 410;
 #else
 static const uint32_t buffer_size = 410;
 #endif
 
-// Holds 5 ms ADC window chunk that was filled before the currrent (adc_buffer_curr_half):
-uint16_t adc_buffer_prev_half[buffer_size];
+// Holds one pair of Goertzel magnitudes:
+// Every time G runs, it gives a magnitude for each of the 2 frequencies we're checking
+struct goertzel_output_t {
+  float mag_2kHz;
+  float mag_2_2kHz;
+};
 
-// adc_buffer_prev_half is considered valid when it holds a full previous DMA buffer,
-// and therefore ready to pair with the current buffer (adc_buffer_curr_half) for decoding:
-bool prev_buffer_half_is_valid = false;
+// Stores recent Goertzel magnitudes for each bit window in a circular buffer:
+static const size_t G_HISTORY_LEN = 16;
+static goertzel_output_t goertzel_history_circ_buffer[G_HISTORY_LEN];
+static size_t goertzel_history_circ_buffer_index = 0;
+
+// If k = the min # of bits that need to be seen in order to identify the bit boundaries in relation to the sampling window,
+// then 2k + = the min # windows (Goertzel outputs) that need to be seen
+// Since k = 3, 2k + 1 = 7
+static const size_t ALIGNMENT_IDENTIFYING_G_OUTPUTS = 7;
+static goertzel_output_t window_history[ALIGNMENT_IDENTIFYING_G_OUTPUTS];
+static size_t window_history_index = 0;
+static bool bit_boundaries_are_known = false;
+static uint8_t bit_alignment_phase = 0; // 0 = even windows, 1 = odd windows
+static bool have_enough_windows = false;
+static size_t windows_collected = 0;
+// TODO: Currently an arbitrary number, might want to review/discuss these tradeoffs:
+// MAX_WEAK_WINDOWS too low: Could drop a signal too early that might otherwise be fine
+// MAX_WEAK_WINDOWS too high: Trying to detect a signal long after it's dropped out, or was never valid to begin with
+static const uint8_t MAX_WEAK_WINDOWS = 3;
+static uint8_t consecutive_weak_windows = 0;
 
 // ADC will sample at freq of 81.92 kHz:
 static const uint32_t adc_sampling_rate = 81920;
@@ -67,10 +84,8 @@ uint16_t tx_display_buffer_length = 0;
 ADC *adc = new ADC();
 DMAChannel dma_ch1;
 
-// Creates second half of buffer that comprises one bit period when combined with adc_buffer_prev_half, and
 // DMAMEM places adc_buffer_curr_half in RAM2 (OCRAM):
 DMAMEM static volatile uint16_t __attribute__((aligned(32))) adc_buffer_curr_half[buffer_size];
-uint16_t adc_buffer_full_bit[buffer_size * 2];
 
 // Gets incremented every time decode_single_bit_from_adc_window() runs, and decoding
 // only happens when adc_window_counter % SCAN_CHAIN_LENGTH == 0:
@@ -97,16 +112,18 @@ static const uint8_t PACKET_START2 = 0x02;
 static const uint8_t PACKET_END1   = 0x03;
 static const uint8_t PACKET_END2   = 0x04;
 
+// For preamble:
+static const uint16_t PREAMBLE_BITS = 35; // unit is bits. 35 bits * 10 ms = 350 ms total preamble length
+
 // ------------------------------------------------------------------
 // Functions
 // ------------------------------------------------------------------
 
 /**
- * Sends data to a DAC via SPI: prepares a 3-byte buffer with an address and a 12-bit value, then
- * sends the data using SPI communication.
- * MCP48CXDX1 -- 24-bit messages.
- * top byte: 5-bit address, 2 "command bits", 1 dont-care
- * bottom 2 bytes: 4 dont-care, 12 data bits
+ * Sends a 24‑bit SPI frame to the DAC: [addr/ctrl (8)] + [data (16)].
+ * For MCP48CxDx1: top byte = 5‑bit register address + 2 command bits (must be 0 to write) + 1 don't‑care.
+ * Lower 16 bits carry the 12‑bit value (left‑aligned as per device spec; unused bits are don't‑care).
+ * Expects value in the 0..4095 range.
  */
 void write_to_dac(uint8_t address, uint16_t value) {
   uint8_t buf[3];
@@ -122,13 +139,45 @@ void write_to_dac(uint8_t address, uint16_t value) {
   SPI.endTransaction();
 }
 
+static inline void transmit_bit(uint8_t bit, const tx_parameters_t* tx_parameters) {
+  // w is the angular frequency, wherein w = 2 * pi * freq
+  const float w = (bit ? (2 * PI * tx_parameters->freq_high / 1e6)
+                       : (2 * PI * tx_parameters->freq_low /  1e6));
+  const unsigned long bit_start_time = micros();
+  unsigned long curr_bit_elapsed_useconds;
+
+  // Generates a sine wave for the current bit:
+  while ((curr_bit_elapsed_useconds = micros() - bit_start_time) < tx_parameters->usec_per_bit) {
+    // The DAC sample value (integer 0–409) computed from the sine at that instant - what we actually write to the DAC:
+    const uint16_t dac_sample_value = (uint16_t)(((sinf(w * curr_bit_elapsed_useconds) + 1.0f) * 0.5f) * 409);
+
+    // Do not want an interrupt to run mid-sample, so:
+    noInterrupts();
+    write_to_dac(0, dac_sample_value);
+    interrupts();
+  }
+}
+
+static inline void transmit_preamble(const tx_parameters_t* tx_parameters) {
+  // Arbitrarily choosing to start the preamble with a 1 instead of a 0:
+  uint8_t curr_bit = 1;
+
+  for (uint16_t i = 0; i < PREAMBLE_BITS; i++) {
+    transmit_bit(curr_bit, tx_parameters);
+    // Bitwise XOR assignment operator is ^=: if b is 1, 1 ^ 1 = 0 and if b is 0, 0 ^ 1 = 1
+    // Alternates 1,0,1,0,...
+    curr_bit ^= 1;
+  }
+}
+
 /**
- * Transmits a message by modulating each character's bits into analog tones.
- * Note: address of 0 --> writing to channel 0 of the DAC.
- * write_to_dac(address=0, val=0): DAC receives a 24-bit message that sets the output to the minimum voltage (0V)
- * write_to_dac(address=0, val=4095): DAC receives a 24-bit message that sets the output to the maximum voltage
+ * FSK transmitter: for each char, emit its 8 bits MSB‑first as tones.
+ * Uses freq_low for 0 and freq_high for 1; each bit lasts usec_per_bit microseconds.
+ * The sine is generated with w = 2πf and time in microseconds, so f is in Hz and time is µs.
+ * Note: the current scaling multiplies by 409 (≈10‑bit). For a 12‑bit DAC, use 4095.
  */
 void transmit_message(const char* message_to_transmit, const tx_parameters_t* tx_parameters) {
+  transmit_preamble(tx_parameters);
   for (int i = 0; message_to_transmit[i] != '\0'; i++) {
     Serial.print("Processing letter: ");
     Serial.println(message_to_transmit[i]);
@@ -144,7 +193,7 @@ void transmit_message(const char* message_to_transmit, const tx_parameters_t* tx
       unsigned long bit_start = micros();
       unsigned long time_usec;
       uint16_t dac_value;
-      // Generates a sine wave for current bit for 10 ms:
+      // Generates a sine wave for the current bit for usec_per_bit microseconds:
       while ((time_usec = micros() - bit_start) < tx_parameters->usec_per_bit) {
         // Gets the phase angle at curr time in microsec and scales for 12 bit DAC:
         dac_value = (uint16_t)(((sin(w * time_usec) + 1.0) / 2.0) * 409);
@@ -167,15 +216,15 @@ void set_charge_amplifier_gain(uint8_t gain_index) {
 }
 
 /**
- * Enables/disables transmission power by writing high or low to the tx_power_en_pin pin.
+ * Enables or disables the TX power rail via tx_power_en_pin.
  */
 inline void set_tx_power_enable(bool enable) {
   digitalWriteFast(tx_power_en_pin, (enable) ? HIGH : LOW);
 }
 
 /**
- * Sets up the transmitter by configuring output pins, enabling transmission power, and writing initial values to a DAC (Digital-to-Analog Converter).
- * Configures gain and voltage references for the DAC.
+ * Initializes TX path: configures control pins, enables TX power, and programs DAC config/VREF.
+ * Note: leaves TX power ON (set_tx_power_enable(true)); caller can disable after transmit.
  */
 void setup_transmitter() {
   pinMode(tx_power_en_pin, OUTPUT);
@@ -191,8 +240,10 @@ void setup_transmitter() {
 }
 
 /**
- * Adds message to chat history and refreshes display,
- * or uses test override if in UNIT_TEST mode.
+ * Delivers a decoded message to the UI:
+ * - In UNIT_TEST, calls an optional test override if set.
+ * - Validates length and rejects protocol framing bytes.
+ * - Strips simple escape chars, appends to chat history, refreshes display.
  */
 void deliver_message(const char* message) {
   // If a test override is set, this will call it instead of performing normal delivery logic.
@@ -206,8 +257,7 @@ void deliver_message(const char* message) {
 
   size_t len = strlen(message);
 
-  // Rejects empty messages:
- // Reject empty or overly long messages:
+  // Reject empty or overly long messages:
   if (len == 0 || len >= MAX_TEXT_LENGTH) return;
   // Rejects framing characters used by protocol:
   for (size_t i = 0; i < len; i++) {
@@ -229,33 +279,119 @@ void deliver_message(const char* message) {
   display_chat_history(state);
 }
 
-/**
- * Appends 0 or 1 to bitstream based on which frequency has higher magnitude.
- */
-void get_bit_from_top_frequency() {
-  // Calculates the magnitude of the complex output for each frequency bin:
-  float mag0 = sqrtf(powf(gs[0].y_re, 2) + powf(gs[0].y_im, 2));
-  float mag1 = sqrtf(powf(gs[1].y_re, 2) + powf(gs[1].y_im, 2));
-  float total_mag = mag0 + mag1;
-
-  // Ignores noisy or weak signals:
-  if (total_mag < MAGNITUDE_THRESHOLD) {
-    return;
+static float average_window_magnitude(size_t window_count) {
+  float sum = 0.0f;
+  for (size_t i = 0; i < window_count; i++) {
+    size_t index = (window_history_index + i) % ALIGNMENT_IDENTIFYING_G_OUTPUTS;
+    sum += window_history[index].mag_2kHz + window_history[index].mag_2_2kHz;
   }
+  return sum / window_count;
+}
 
-  uint8_t bit = (mag1 > mag0) ? 1 : 0;
+static inline uint8_t determine_bit(const goertzel_output_t* g_ouput) {
+  if (g_ouput->mag_2_2kHz > g_ouput->mag_2kHz) return 1;
+  if (g_ouput->mag_2_2kHz < g_ouput->mag_2kHz) return 0;
+  return 255; // out of range value (uint8_t ~ 0-255) that can be used to check for error case
+}
 
-  if (bit_index < MAX_BITS) {
-    bitstream[bit_index++] = bit;
+static void find_bit_boundaries(void) {
+  if (!have_enough_windows || bit_boundaries_are_known) return;
+
+  // Basically just deciding here the signal is viable if the average magnitude is above some predetermined threshold
+  float avg_mag = average_window_magnitude(ALIGNMENT_IDENTIFYING_G_OUTPUTS);
+  if (avg_mag < MAGNITUDE_THRESHOLD) return;
+
+  // Outer loop tries both phases
+  for (uint8_t phase = 0; phase < 2; phase++) {
+    int alternating_pairs = 0;
+
+    // Inner loop tries pairs of windows for each phase
+    for (size_t i = 0; i + 1 < ALIGNMENT_IDENTIFYING_G_OUTPUTS; i += 2) {
+      size_t idx0 = (window_history_index + i + phase) % ALIGNMENT_IDENTIFYING_G_OUTPUTS;
+      size_t idx1 = (window_history_index + i + 1 + phase) % ALIGNMENT_IDENTIFYING_G_OUTPUTS;
+
+      uint8_t b0 = determine_bit(&window_history[idx0]);
+      uint8_t b1 = determine_bit(&window_history[idx1]);
+
+      // Skip if either window was ambiguous (tie → 255)
+      if (b0 == 255 || b1 == 255) continue;
+      if (b0 != b1) {
+        alternating_pairs++;
+      }
+
+    }
+
+    // If we saw 3 alternating pairs, assume we found the correct bit boundaries
+    if (alternating_pairs >= 3) {
+      bit_alignment_phase = phase;
+      bit_boundaries_are_known = true;
+      return; // stop searching once locked
+    }
+
   }
-
 }
 
 /**
- * Reconstructs bytes from bitstream, extracts a valid message
- * between header/footer, and delivers it to chat history.
+ * Computes Goertzel magnitudes for 2.0 kHz and 2.2 kHz, logs them, and (if signal is strong enough)
+ * appends 0/1 to bitstream based on which bin is larger.
+ * Uses MAGNITUDE_THRESHOLD on (mag_2kHz + mag_2_2kHz) to suppress noise.
  */
-void parse_message() {
+void get_bit_from_top_frequency() {
+  // Calculates the magnitude of the complex output for each frequency bin:
+  float mag_2kHz = sqrtf(powf(gs[0].y_re, 2) + powf(gs[0].y_im, 2));
+  float mag_2_2kHz = sqrtf(powf(gs[1].y_re, 2) + powf(gs[1].y_im, 2));
+
+  // Stores magnitudes in circ buffer for later analysis:
+  goertzel_history_circ_buffer[goertzel_history_circ_buffer_index] = { mag_2kHz, mag_2_2kHz };
+  goertzel_history_circ_buffer_index = (goertzel_history_circ_buffer_index + 1) % G_HISTORY_LEN;
+
+  // Keeps a short rolling history used for boundary detection:
+  window_history[window_history_index] = { mag_2kHz, mag_2_2kHz };
+  window_history_index = (window_history_index + 1) % ALIGNMENT_IDENTIFYING_G_OUTPUTS;
+
+  // Keep counting windows until we’ve seen enough to attempt boundary detection:
+  if (!have_enough_windows) {
+    windows_collected++;
+    if (windows_collected >= ALIGNMENT_IDENTIFYING_G_OUTPUTS) {
+      have_enough_windows = true;
+    }
+  }
+
+  // Use the rolling window_history to determine where bit edges fall (sets bit_boundaries_are_known/bit_alignment_phase):
+  find_bit_boundaries();
+
+  // If boundaries aren’t established yet, stop here (only magnitudes logged this window):
+  if (!bit_boundaries_are_known) return;
+  else {
+    // Boundaries are known → keep monitoring average strength:
+    float avg_mag_lock = average_window_magnitude(ALIGNMENT_IDENTIFYING_G_OUTPUTS);
+    if (avg_mag_lock < MAGNITUDE_THRESHOLD) {
+      if (++consecutive_weak_windows >= MAX_WEAK_WINDOWS) {
+        // Signal stayed weak too long → reset state:
+        bit_boundaries_are_known = false;
+        consecutive_weak_windows = 0;
+        have_enough_windows = false;
+        windows_collected = 0;
+        return; // don't need to proceed with trying to append a bit at this point
+      }
+    } else {
+      consecutive_weak_windows = 0;
+    }
+  }
+
+  // Decide this window’s bit (1 if 2.2 kHz stronger, else 0) and append if there’s space:
+  uint8_t bit = (mag_2_2kHz > mag_2kHz) ? 1 : 0;
+  if (bit_index < MAX_BITS) {
+    bitstream[bit_index++] = bit;
+  }
+}
+
+/**
+ * Reassembles bytes MSB‑first from bitstream[], searches for 2‑byte header/footer,
+ * copies the payload to a C‑string, delivers it, then resets the bit buffer.
+ * Header: PACKET_START1, PACKET_START2. Footer: PACKET_END1, PACKET_END2.
+ */
+void check_for_complete_packet() {
   // Buffer to hold reconstructed bytes from the bitstream:
   static char decoded_bytes[MAX_PACKET_SIZE];
 
@@ -313,10 +449,11 @@ void parse_message() {
 }
 
 /**
- * Applies a function to each goertzel_state in gs[].
- * Pass either one_param_fn (if sample == -1) or two_param_fn with a sample.
- * Only one function pointer should be non-NULL.
-*/
+ * Applies a callback to each goertzel_state in gs[].
+ * Pass exactly one of:
+ *  - two_param_fn(g, sample) to process a sample, or
+ *  - one_param_fn(g) for no‑sample ops (finalize/reset). In this case pass sample = -1.
+ */
 void for_each_goertzel_state(void (*one_param_fn)(goertzel_state*), void (*two_param_fn)(goertzel_state*, int), int sample) {
   for (int i = 0; i < gs_len; i++) {
     // Gets a pointer to the j-th element of the gs array, which holds Goertzel filter state:
@@ -331,60 +468,50 @@ void for_each_goertzel_state(void (*one_param_fn)(goertzel_state*), void (*two_p
 }
 
 /**
- * Processes one full ADC window to decode a bit, updates the bitstream, and attempts message parsing.
+ * Processes one ADC window at bit-aligned intervals:
+ * runs Goertzel, extracts a bit, appends it to the bitstream, checks for a complete packet, then resets Goertzel state.
  */
-void decode_single_bit_from_adc_window() {
-  // Skips processing unless a full bit period's worth of data is ready:
-  if (adc_window_counter++ % SCAN_CHAIN_LENGTH != 0) return;
+void decode_single_bit_from_adc_window(const uint16_t* samples, size_t size) {
+  uint8_t curr_phase = adc_window_counter++ % SCAN_CHAIN_LENGTH;
 
-  // For each ADC sample in the buffer, update each Goertzel filter state with this sample:
-  for (size_t i = 0; i < buffer_size; i++) {
-    for_each_goertzel_state(NULL, update_goertzel, adc_buffer_full_bit[i]);
+  // If we know for sure the current window is out of phase, don't bother
+  // with processing it:
+  if (bit_boundaries_are_known && curr_phase != bit_alignment_phase) return;
+
+  // Feeds each ADC sample into the Goertzel filters:
+  for (size_t i = 0; i < size; i++) {
+    for_each_goertzel_state(NULL, update_goertzel, samples[i]);
   }
 
+  // Computes this window’s frequency results:
   for_each_goertzel_state(finalize_goertzel, NULL, -1);
 
   get_bit_from_top_frequency();
-  parse_message();
+  check_for_complete_packet();
 
   // Resets internal Goertzel state (not y_re/y_im):
   for_each_goertzel_state(reset_goertzel, NULL, -1);
 }
 
 /**
- * Called when DMA fills the ADC buffer. It clears the DMA interrupt, copies the buffer, re-enables DMA, and
- * triggers bit extraction from the data.
- - A bit is encoded over 10 ms of audio.
- - Each ADC buffer = 5 ms of samples (410 samples at 81.92 kHz).
- - Therefore, two buffers = 1 bit period.
+ * Called when DMA fills the ADC buffer. Clears the DMA interrupt, invalidates CPU cache for the DMA buffer,
+ * passes the fresh samples to the decoder, then re-enables DMA.
+ * DMA writes to RAM2 -> decode_single_bit_from_adc_window reads from RAM2.
+ * Each ADC buffer ≈ 5 ms (410 samples @ 81.92 kHz). If SCAN_CHAIN_LENGTH == 2 and TX bit period is ~10 ms,
+ * two buffers correspond to one bit period.
  */
 void adc_buffer_full_interrupt() {
   // Clears the DMA interrupt flag so it's ready for the next transfer:
   dma_ch1.clearInterrupt();
 
-  if (prev_buffer_half_is_valid) {
-    // Combines prev + current into adc_buffer_full_bit:
-    memcpy(adc_buffer_full_bit, adc_buffer_prev_half, sizeof(adc_buffer_prev_half));
-    memcpy(adc_buffer_full_bit + buffer_size, (const void*)adc_buffer_curr_half, sizeof(adc_buffer_curr_half));
-  } else {
-    // Not ready to decode yet, just store current into prev and return:
-    memcpy(adc_buffer_prev_half, (const void*)adc_buffer_curr_half, sizeof(adc_buffer_curr_half));
-    prev_buffer_half_is_valid = true;
-    dma_ch1.enable();
-    return;
-  }
-
   // Invalidates CPU cache for adc_buffer_curr_half to ensure CPU sees the latest data written by DMA (RAM2 is cacheable):
-  if ((uint32_t)adc_buffer_curr_half >= 0x20200000u) {
-    arm_dcache_delete((void *)adc_buffer_curr_half, sizeof(adc_buffer_curr_half));
-  }
+  arm_dcache_delete((void *)adc_buffer_curr_half, sizeof(adc_buffer_curr_half));
+
+  // Uses Goertzel algorithm to analyze the frequency content of a full buffer of ADC samples:
+  decode_single_bit_from_adc_window((const uint16_t*)adc_buffer_curr_half, buffer_size);
 
   // Re-enables the DMA channel for next read:
   dma_ch1.enable();
-
-  // Uses Goertzel algorithm to analyze the frequency content of a series of ADC samples:
-  decode_single_bit_from_adc_window();
-  prev_buffer_half_is_valid = false;
 }
 
 /**
@@ -415,7 +542,7 @@ void setup_receiver() {
   dma_ch1.source((volatile uint16_t &)(ADC1_R0));
   #pragma GCC diagnostic pop
 
-  // Each time you sample from ADC you get 2 bytes, so that's why we're using buffer_size * 2:
+  // destinationBuffer takes a sample count here (not bytes). The library handles element width internally:
   dma_ch1.destinationBuffer((uint16_t *)adc_buffer_curr_half, buffer_size);
   dma_ch1.interruptAtCompletion();
   dma_ch1.disableOnCompletion();
@@ -471,18 +598,9 @@ uint8_t* _test_get_adc_window_counter() {
   return &adc_window_counter;
 }
 
-uint16_t* _test_get_adc_buffer_prev_half() {
-  return adc_buffer_prev_half;
-}
-
 // Returns a pointer to adc_buffer_curr_half so tests can fill it with mock ADC data - volatile because it's the DMA destination:
 volatile uint16_t* _test_get_adc_buffer_curr_half() {
   return adc_buffer_curr_half;
-}
-
-// Returns a pointer to adc_buffer_full_bit	so tests can inspect or clear copied ADC data:
-uint16_t* _test_get_adc_buffer_full_bit() {
-  return adc_buffer_full_bit;
 }
 
 #endif

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -24,6 +24,16 @@
 static void (*deliver_fn_override)(const char*) = nullptr;
 #endif
 
+// For debugging only:
+inline void pulse_begin() { digitalWriteFast(1, HIGH); }
+inline void pulse_end()   { digitalWriteFast(1, LOW); }
+
+// Temp changes to log sampling rate:
+// start changes---------------------------------------------------
+volatile uint32_t buffer_count = 0;
+uint32_t start_time_us = 0;
+// end changes-----------------------------------------------------
+
 // ------------------------------------------------------------------
 // State
 // ------------------------------------------------------------------
@@ -439,16 +449,6 @@ void get_bit_from_top_frequency() {
     }
   }
 
-  // Testing only----------------------------------------------------
-  // Decide this window’s bit (1 if 2.2 kHz stronger, else 0) and append if there’s space:
-  // Symbol s = decide_symbol(mag_2kHz, mag_2_2kHz);
-  // if (s == SYM_SILENCE) {
-  //   Serial.println("S==================");    // log silence explicitly
-  //   return;                 // do not append a bit during gaps
-  // }
-  // uint8_t bit = (s == SYM_1) ? 1 : 0;
-  // End testing-----------------------------------------------------
-
   uint8_t bit = (mag_2_2kHz > mag_2kHz) ? 1 : 0;
   if (bit_index < MAX_BITS) {
     bitstream[bit_index++] = bit;
@@ -459,12 +459,6 @@ void get_bit_from_top_frequency() {
     }
     Serial.println(bit);
 
-    // Testing only--------------------------------------------------
-    pinMode(1, OUTPUT);
-    digitalWrite(1, HIGH);
-    delay(1);
-    digitalWrite(1, LOW);
-    // End testing---------------------------------------------------
   }
 }
 
@@ -580,11 +574,25 @@ void decode_single_bit_from_adc_window(const uint16_t* samples, size_t size) {
  * passes the fresh samples to the decoder, then re-enables DMA.
  * DMA writes to RAM2 -> decode_single_bit_from_adc_window reads from RAM2.
  * Each ADC buffer ≈ 5 ms (410 samples @ 81.92 kHz). If SCAN_CHAIN_LENGTH == 2 and TX bit period is ~10 ms,
- * two buffers correspond to one bit period.
+ * two buffers correspond to one bit period, and adc_buffer_full_interrupt() fires every 5 ms.
  */
 void adc_buffer_full_interrupt() {
+  pulse_begin();
+
   // Clears the DMA interrupt flag so it's ready for the next transfer:
   dma_ch1.clearInterrupt();
+
+  // Temp changes to log sampling rate:
+  // start changes---------------------------------------------------
+  buffer_count++;
+  // end changes-----------------------------------------------------
+
+  // Temp changes to log how many samples in buffer:
+  // start changes---------------------------------------------------
+  // static uint32_t total_samples = 0;
+  // total_samples += buffer_size;  // how many samples DMA says it just finished
+  // Serial.printf("DMA complete: total_samples=%lu\n", total_samples); // should increase by +410 each time
+  // end changes-----------------------------------------------------
 
   // Invalidates CPU cache for adc_buffer_curr_half to ensure CPU sees the latest data written by DMA (RAM2 is cacheable):
   arm_dcache_delete((void *)adc_buffer_curr_half, sizeof(adc_buffer_curr_half));
@@ -594,6 +602,8 @@ void adc_buffer_full_interrupt() {
 
   // Re-enables the DMA channel for next read:
   dma_ch1.enable();
+
+  pulse_end();
 }
 
 /**
@@ -601,6 +611,10 @@ void adc_buffer_full_interrupt() {
  * sets the gain on the charge amplifier, sets up DMA channel for ADC to send data to buffer.
  */
 void setup_receiver() {
+  // For pulse_begin() / pulse_end():
+  pinMode(1, OUTPUT);
+  digitalWriteFast(1, LOW);
+
   // Sets readPin_adc_0_pin as the input pin for ADC sampling:
   pinMode(readPin_adc_0_pin, INPUT);
 
@@ -624,8 +638,8 @@ void setup_receiver() {
   dma_ch1.source((volatile uint16_t &)(ADC1_R0));
   #pragma GCC diagnostic pop
 
-  // destinationBuffer takes a sample count here (not bytes). The library handles element width internally:
-  dma_ch1.destinationBuffer((uint16_t *)adc_buffer_curr_half, buffer_size);
+  // destinationBuffer takes a byte count here (not samples). The library handles element width internally:
+  dma_ch1.destinationBuffer((uint16_t *)adc_buffer_curr_half, sizeof(adc_buffer_curr_half));
   dma_ch1.interruptAtCompletion();
   dma_ch1.disableOnCompletion();
 

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -295,14 +295,14 @@ void deliver_message(const char* message) {
 }
 
 /**
- * Computes average combined magnitude over `window_count` entries starting at window_history_index
+ * Computes average combined magnitude over `window_count` entries in the circular history starting at `history_index`
  * (not strictly “most recent”).
  */
-static float average_window_magnitude(size_t window_count) {
+static float average_window_magnitude(size_t window_count, const goertzel_output_t* window_hist, size_t history_index) {
   float sum = 0.0f;
   for (size_t i = 0; i < window_count; i++) {
-    size_t index = (window_history_index + i) % ALIGNMENT_IDENTIFYING_G_OUTPUTS;
-    sum += window_history[index].mag_2kHz + window_history[index].mag_2_2kHz;
+    size_t index = (history_index + i) % ALIGNMENT_IDENTIFYING_G_OUTPUTS;
+    sum += window_hist[index].mag_2kHz + window_hist[index].mag_2_2kHz;
   }
   return sum / window_count;
 }
@@ -327,7 +327,7 @@ static void find_bit_boundaries(void) {
   if (!have_enough_windows || bit_boundaries_are_known) return;
 
   // Basically just deciding here the signal is viable if the average magnitude is above some predetermined threshold
-  float avg_mag = average_window_magnitude(ALIGNMENT_IDENTIFYING_G_OUTPUTS);
+  float avg_mag = average_window_magnitude(ALIGNMENT_IDENTIFYING_G_OUTPUTS, window_history, window_history_index);
   if (avg_mag < MAGNITUDE_THRESHOLD) return;
 
   // Outer loop tries both phases
@@ -410,7 +410,7 @@ void get_bit_from_top_frequency() {
   }
 
   // Boundaries are known → keep monitoring average strength:
-  float avg_mag_lock = average_window_magnitude(ALIGNMENT_IDENTIFYING_G_OUTPUTS);
+  float avg_mag_lock = average_window_magnitude(ALIGNMENT_IDENTIFYING_G_OUTPUTS, window_history, window_history_index);
   if (avg_mag_lock < MAGNITUDE_THRESHOLD) {
     if (++consecutive_weak_windows >= MAX_WEAK_WINDOWS) {
       // Signal stayed weak too long → reset state:

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -61,7 +61,6 @@ static uint16_t rx_win_q[WINDOWS_PER_BIT][buffer_size];
 static volatile uint8_t rx_queue_write_index = 0;
 static volatile uint8_t rx_queue_read_index = 0;
 static volatile uint8_t rx_queue_count = 0;
-static volatile bool rx_queue_overrun = false;
 
 // Holds one pair of Goertzel magnitudes (2.0 kHz + 2.2 kHz)
 struct goertzel_output_t {
@@ -376,7 +375,6 @@ static void find_bit_boundaries(void) {
 static void reset_receiver_state() {
   noInterrupts();
   rx_queue_write_index = rx_queue_read_index = rx_queue_count = 0;
-  rx_queue_overrun = false;
   interrupts();
 
   window_index = 0;
@@ -586,8 +584,6 @@ void adc_buffer_full_interrupt() {
            sizeof(rx_win_q[0]));
     rx_queue_write_index = (rx_queue_write_index + 1) & 1;
     rx_queue_count++;
-  } else {
-    rx_queue_overrun = true; // dropped a window because loop couldn't keep up
   }
 
   // Re-enables the DMA channel for next read:

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -548,7 +548,8 @@ void adc_buffer_full_interrupt() {
   // Invalidates CPU cache for adc_dma_window to ensure CPU sees the latest data written by DMA (RAM2 is cacheable):
   arm_dcache_delete((void *)adc_dma_window, sizeof(adc_dma_window));
 
-  // copy 1 window into RAM1 queue (fast) instead of calling decode_single_bit_from_adc_window
+  // Copy 1 window into RAM1 queue (fast). If queue is full (2 slots), drop this window so the
+  // main loop always sees a consistent pair; overwriting would mix old and new data in one slot.
   if (rx_queue_count < 2) {
     memcpy(rx_win_q[rx_queue_write_index],
            (const void*)adc_dma_window,
@@ -568,7 +569,7 @@ void adc_buffer_full_interrupt() {
 void process_rx_windows() {
   static uint8_t scan_div = 0;
 
-  while (true) {
+  while (rx_queue_count != 0) {
     noInterrupts();
     if (rx_queue_count == 0) { interrupts(); break; }
     uint8_t slot = rx_queue_read_index;

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -125,6 +125,33 @@ volatile bool mag_ready = false;
 // Functions
 // ------------------------------------------------------------------
 
+// Testing only------------------------------------------------------
+// Decide: 1, 0, or SILENCE based on Goertzel magnitudes
+enum Symbol { SYM_0, SYM_1, SYM_SILENCE };
+
+static inline Symbol decide_symbol(float P0, float P1) {
+  // 1) Energy gate (silence)
+  const float E = P0 + P1;                // total energy in this window
+  static float noise_ema = 0.0f;
+  if (noise_ema == 0.0f) noise_ema = E;   // init
+  // track floor only when low energy so strong tones don't raise it
+  if (E < noise_ema * 1.5f) noise_ema = 0.95f*noise_ema + 0.05f*E;
+
+  const float ABS_FLOOR = 0.1f;   // was 200.0f
+  const float THRESH    = fmaxf(ABS_FLOOR, noise_ema * 3.0f);
+  if (E < THRESH) return SYM_SILENCE;
+
+  // 2) Dominance gate (avoid random argmax in noise)
+  const float maxmag = (P1 > P0) ? P1 : P0;
+  const float minmag = (P1 > P0) ? P0 : P1;
+  const float MIN_DOM_RATIO = 0.3f;  // was 1.6f
+  if (maxmag < MIN_DOM_RATIO * minmag) return SYM_SILENCE;
+
+  // 3) Decide bit
+  return (P1 > P0) ? SYM_1 : SYM_0;
+}
+// End testing only--------------------------------------------------
+
 static inline void update_magnitudes_to_plot(float mag_2_kHz, float mag_2_2_kHz) {
   curr_mag_2kHz = mag_2_kHz;
   curr_mag_2_2kHz = mag_2_2_kHz;
@@ -164,8 +191,8 @@ static inline void transmit_bit(uint8_t bit, const tx_parameters_t* tx_parameter
 
   // Generates a sine wave for the current bit:
   while ((curr_bit_elapsed_useconds = micros() - bit_start_time) < tx_parameters->usec_per_bit) {
-    // The DAC sample value (integer 0–409) computed from the sine at that instant - what we actually write to the DAC:
-    const uint16_t dac_sample_value = (uint16_t)(((sinf(w * curr_bit_elapsed_useconds) + 1.0f) * 0.5f) * 409);
+    // The DAC sample value (integer 0–4095) computed from the sine at that instant - what we actually write to the DAC:
+    const uint16_t dac_sample_value = (uint16_t)(((sinf(w * curr_bit_elapsed_useconds) + 1.0f) * 0.5f) * 4095);
 
     // Do not want an interrupt to run mid-sample, so:
     noInterrupts();
@@ -194,7 +221,6 @@ static inline void transmit_preamble(const tx_parameters_t* tx_parameters) {
  * FSK transmitter: for each char, emit its 8 bits MSB‑first as tones.
  * Uses freq_low for 0 and freq_high for 1; each bit lasts usec_per_bit microseconds.
  * The sine is generated with w = 2πf and time in microseconds, so f is in Hz and time is µs.
- * Note: the current scaling multiplies by 409 (≈10‑bit). For a 12‑bit DAC, use 4095.
  */
 void transmit_message(const char* message_to_transmit, const tx_parameters_t* tx_parameters) {
   transmit_preamble(tx_parameters);
@@ -216,7 +242,7 @@ void transmit_message(const char* message_to_transmit, const tx_parameters_t* tx
       // Generates a sine wave for the current bit for usec_per_bit microseconds:
       while ((time_usec = micros() - bit_start) < tx_parameters->usec_per_bit) {
         // Gets the phase angle at curr time in microsec and scales for 12 bit DAC:
-        dac_value = (uint16_t)(((sin(w * time_usec) + 1.0) / 2.0) * 409);
+        dac_value = (uint16_t)(((sin(w * time_usec) + 1.0) / 2.0) * 4095);
         noInterrupts();
         write_to_dac(0, dac_value);
         interrupts();
@@ -413,12 +439,30 @@ void get_bit_from_top_frequency() {
     }
   }
 
+  // Testing only----------------------------------------------------
   // Decide this window’s bit (1 if 2.2 kHz stronger, else 0) and append if there’s space:
+  // Symbol s = decide_symbol(mag_2kHz, mag_2_2kHz);
+  // if (s == SYM_SILENCE) {
+  //   Serial.println("S==================");    // log silence explicitly
+  //   return;                 // do not append a bit during gaps
+  // }
+  // uint8_t bit = (s == SYM_1) ? 1 : 0;
+  // End testing-----------------------------------------------------
+
   uint8_t bit = (mag_2_2kHz > mag_2kHz) ? 1 : 0;
   if (bit_index < MAX_BITS) {
     bitstream[bit_index++] = bit;
-    Serial.print("bit: ");
+    if (bit == 0) {
+      Serial.print("bit 0: ");
+    } else {
+      Serial.print("bit 1: ");
+    }
     Serial.println(bit);
+
+    pinMode(1, OUTPUT);
+    digitalWrite(1, HIGH);
+    delay(1);
+    digitalWrite(1, LOW);
   }
 }
 

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -95,7 +95,7 @@ static uint8_t adc_window_counter = 0;
 
 // Goertzel filter state (one per target frequency)
 static const uint8_t gs_len = 2;   // only 2 bins: 2.0 kHz and 2.2 kHz
-goertzel_state gs[gs_len];
+static goertzel_state gs[gs_len];
 
 // Charge amplifier gain:
 static const int adg728_i2c_address = 76;

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -41,18 +41,7 @@ static void (*deliver_fn_override)(const char*) = nullptr;
 
 // Number of ADC samples per DMA transfer into adc_dma_window.
 // Samples per window (buffer_size) = adc_sampling_rate * window_duration = 81,920 * 5 ms = 410 samples.
-#ifdef UNIT_TEST
-const uint32_t buffer_size = 410;
-#else
-static const uint32_t buffer_size = 410;
-#endif
-
-#ifdef UNIT_TEST
-const int WINDOWS_PER_BIT = 2;
-#else
-static const int WINDOWS_PER_BIT = 2;
-#endif
-
+// buffer_size and WINDOWS_PER_BIT are #defined in comm.h.
 static const float MIN_TONE_MAGNITUDE = 1.0f; // Update value later with more testing
 
 // 2-window queue in RAM1 (DTCM). Each window is one 5ms window (410 samples).
@@ -63,10 +52,10 @@ static volatile uint8_t rx_queue_read_index = 0;
 static volatile uint8_t rx_queue_count = 0;
 
 // Holds one pair of Goertzel magnitudes (2.0 kHz + 2.2 kHz)
-struct goertzel_output_t {
+typedef struct _goertzel_output {
   float mag_2kHz;
   float mag_2_2kHz;
-};
+} goertzel_output_t;
 
 // Stores recent Goertzel magnitudes in a circular buffer
 static const size_t G_HISTORY_LEN = 16;
@@ -141,7 +130,7 @@ static const uint16_t PREAMBLE_BITS = 35; // bits; duration depends on tx_parame
 /**
  * Sends a 24‑bit SPI frame to the DAC: [addr/ctrl (8)] + [data (16)].
  * For MCP48CxDx1: top byte = 5‑bit register address + 2 command bits (must be 0 to write) + 1 don't‑care.
- * Lower 16 bits carry the 12‑bit value (left‑aligned as per device spec; unused bits are don't‑care).
+ * Lower 16 bits carry the 12‑bit value (right‑aligned: bits 15–12 ignored, 11–0 used).
  * Expects value in the 0..4095 range.
  */
 void write_to_dac(uint8_t address, uint16_t value) {
@@ -369,9 +358,6 @@ static void find_bit_boundaries(void) {
   }
 }
 
-/**
- *
- */
 static void reset_receiver_state() {
   noInterrupts();
   rx_queue_write_index = rx_queue_read_index = rx_queue_count = 0;

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -44,7 +44,8 @@ static void (*deliver_fn_override)(const char*) = nullptr;
 // buffer_size and WINDOWS_PER_BIT are #defined in comm.h.
 static const float MIN_TONE_MAGNITUDE = 1.0f; // Update value later with more testing
 
-// 2-window queue in RAM1 (DTCM). Each window is one 5ms window (410 samples).
+// 2-slot queue in RAM1 (DTCM). Double-buffer: ISR writes one slot while main loop reads the other,
+// so we never process a window that DMA is still filling. Each slot is one 5 ms window (410 samples).
 static uint16_t rx_win_q[WINDOWS_PER_BIT][buffer_size];
 
 static volatile uint8_t rx_queue_write_index = 0;
@@ -57,14 +58,13 @@ typedef struct _goertzel_output {
   float mag_2_2kHz;
 } goertzel_output_t;
 
-// Stores recent Goertzel magnitudes in a circular buffer
+// Long history: optional analysis/plotting. Short rolling window below is used for bit-boundary detection.
 static const size_t G_HISTORY_LEN = 16;
 static goertzel_output_t goertzel_history_circ_buffer[G_HISTORY_LEN];
 static size_t goertzel_history_circ_buffer_index = 0;
 
 // If k = min bits needed to identify bit boundaries relative to sampling windows,
-// then 2k + 1 = min windows (Goertzel outputs) that need to be seen
-// Since k = 3, 2k + 1 = 7
+// then 2k + 1 = min windows (Goertzel outputs) that need to be seen. Since k = 3, 2k + 1 = 7.
 static const size_t ALIGNMENT_IDENTIFYING_G_OUTPUTS = 7;
 static goertzel_output_t window_history[ALIGNMENT_IDENTIFYING_G_OUTPUTS];
 static size_t window_history_index = 0;
@@ -200,22 +200,7 @@ void transmit_message(const char* message_to_transmit, const tx_parameters_t* tx
 
     // Translates each of char's 8 bits into a corresponding frequency starting with msb:
     for (int j = 7; j >= 0; j--) {
-      int bit = (letter >> j) & 1;
-      // w is radians per microsecond: w = 2πf / 1e6 (f in Hz)
-      float w = (bit) ? (2 * PI * tx_parameters->freq_high / 1e6)
-                      : (2 * PI * tx_parameters->freq_low / 1e6);
-      // Start time for the current bit period:
-      unsigned long bit_start = micros();
-      unsigned long time_usec;
-      uint16_t dac_value;
-      // Generates a sine wave for the current bit for usec_per_bit microseconds:
-      while ((time_usec = micros() - bit_start) < tx_parameters->usec_per_bit) {
-        // Gets the phase angle at curr time in microsec and scales for 12 bit DAC:
-        dac_value = (uint16_t)(((sin(w * time_usec) + 1.0) / 2.0) * 4095);
-        noInterrupts();
-        write_to_dac(0, dac_value);
-        interrupts();
-      }
+      transmit_bit((uint8_t)((letter >> j) & 1), tx_parameters);
     }
   }
 }

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -29,7 +29,7 @@ static void (*deliver_fn_override)(const char*) = nullptr;
 // ------------------------------------------------------------------
 
 /*
-  adc_buffer_curr_half is filled by the DMA and declared with DMAMEM and __attribute__((aligned(32)))
+  adc_dma_window is filled by the DMA and declared with DMAMEM and __attribute__((aligned(32)))
   to place it in RAM2 (OCRAM), which is cacheable and requires manual cache management.
 
   RAM1 = DTCM (Tightly Coupled Memory) --> Not cacheable. Always in sync.
@@ -39,7 +39,7 @@ static void (*deliver_fn_override)(const char*) = nullptr;
   arm_dcache_delete() discards cache so the CPU reads fresh data from RAM2.
 */
 
-// Number of ADC samples per DMA transfer into adc_buffer_curr_half.
+// Number of ADC samples per DMA transfer into adc_dma_window.
 // Samples per window (buffer_size) = adc_sampling_rate * window_duration = 81,920 * 5 ms = 410 samples.
 #ifdef UNIT_TEST
 const uint32_t buffer_size = 410;
@@ -99,8 +99,8 @@ uint16_t tx_display_buffer_length = 0;
 ADC *adc = new ADC();
 DMAChannel dma_ch1;
 
-// DMAMEM places adc_buffer_curr_half in RAM2 (OCRAM):
-DMAMEM static volatile uint16_t __attribute__((aligned(32))) adc_buffer_curr_half[buffer_size];
+// DMAMEM places adc_dma_window in RAM2 (OCRAM):
+DMAMEM static volatile uint16_t __attribute__((aligned(32))) adc_dma_window[buffer_size];
 
 // Gets incremented every time decode_single_bit_from_adc_window() runs
 static uint8_t adc_window_counter = 0;
@@ -576,13 +576,13 @@ void adc_buffer_full_interrupt() {
   // Clears the DMA interrupt flag so it's ready for the next transfer:
   dma_ch1.clearInterrupt();
 
-  // Invalidates CPU cache for adc_buffer_curr_half to ensure CPU sees the latest data written by DMA (RAM2 is cacheable):
-  arm_dcache_delete((void *)adc_buffer_curr_half, sizeof(adc_buffer_curr_half));
+  // Invalidates CPU cache for adc_dma_window to ensure CPU sees the latest data written by DMA (RAM2 is cacheable):
+  arm_dcache_delete((void *)adc_dma_window, sizeof(adc_dma_window));
 
   // copy 1 window into RAM1 queue (fast) instead of calling decode_single_bit_from_adc_window
   if (rx_queue_count < 2) {
     memcpy(rx_win_q[rx_queue_write_index],
-           (const void*)adc_buffer_curr_half,
+           (const void*)adc_dma_window,
            sizeof(rx_win_q[0]));
     rx_queue_write_index = (rx_queue_write_index + 1) & 1;
     rx_queue_count++;
@@ -640,7 +640,7 @@ void setup_receiver() {
   adc->adc0->setResolution(12); // bits
   adc->adc0->setConversionSpeed(ADC_CONVERSION_SPEED::HIGH_SPEED);
 
-  // Configures DMA to transfer ADC samples into adc_buffer_curr_half:
+  // Configures DMA to transfer ADC samples into adc_dma_window:
   // Note: The following line may raise a compiler warning because type-punning ADC1_R0 here violates strict aliasing rules, but can be safely ignored
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wstrict-aliasing"
@@ -648,7 +648,7 @@ void setup_receiver() {
   #pragma GCC diagnostic pop
 
   // destinationBuffer takes a byte count here (not samples). The library handles element width internally:
-  dma_ch1.destinationBuffer((uint16_t *)adc_buffer_curr_half, sizeof(adc_buffer_curr_half));
+  dma_ch1.destinationBuffer((uint16_t *)adc_dma_window, sizeof(adc_dma_window));
   dma_ch1.interruptAtCompletion();
   dma_ch1.disableOnCompletion();
 
@@ -703,9 +703,9 @@ uint8_t* _test_get_adc_window_counter() {
   return &adc_window_counter;
 }
 
-// Returns a pointer to adc_buffer_curr_half so tests can fill it with mock ADC data - volatile because it's the DMA destination:
-volatile uint16_t* _test_get_adc_buffer_curr_half() {
-  return adc_buffer_curr_half;
+// Returns a pointer to adc_dma_window so tests can fill it with mock ADC data - volatile because it's the DMA destination:
+volatile uint16_t* _test_get_adc_dma_window() {
+  return adc_dma_window;
 }
 
 #endif

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -459,10 +459,12 @@ void get_bit_from_top_frequency() {
     }
     Serial.println(bit);
 
+    // Testing only--------------------------------------------------
     pinMode(1, OUTPUT);
     digitalWrite(1, HIGH);
     delay(1);
     digitalWrite(1, LOW);
+    // End testing---------------------------------------------------
   }
 }
 

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -115,9 +115,21 @@ static const uint8_t PACKET_END2   = 0x04;
 // For preamble:
 static const uint16_t PREAMBLE_BITS = 35; // unit is bits. 35 bits * 10 ms = 350 ms total preamble length
 
+// Plotting amplitude values:
+// Since these are updated within an interrupt, made these volatile-qualified to ensure the compiler is reading/writing these directly to/from memory instead of to/from a CPU register with potentially outdated data:
+volatile float curr_mag_2kHz = 0.0;
+volatile float curr_mag_2_2kHz = 0.0;
+volatile bool mag_ready = false;
+
 // ------------------------------------------------------------------
 // Functions
 // ------------------------------------------------------------------
+
+static inline void update_magnitudes_to_plot(float mag_2_kHz, float mag_2_2_kHz) {
+  curr_mag_2kHz = mag_2_kHz;
+  curr_mag_2_2kHz = mag_2_2_kHz;
+  mag_ready = true;
+}
 
 /**
  * Sends a 24‑bit SPI frame to the DAC: [addr/ctrl (8)] + [data (16)].
@@ -360,6 +372,8 @@ void get_bit_from_top_frequency() {
   // Calculates the magnitude of the complex output for each frequency bin:
   float mag_2kHz = sqrtf(powf(gs[0].y_re, 2) + powf(gs[0].y_im, 2));
   float mag_2_2kHz = sqrtf(powf(gs[1].y_re, 2) + powf(gs[1].y_im, 2));
+
+  update_magnitudes_to_plot(mag_2kHz, mag_2_2kHz);
 
   // Stores magnitudes in circ buffer for later analysis:
   goertzel_history_circ_buffer[goertzel_history_circ_buffer_index] = { mag_2kHz, mag_2_2kHz };

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -570,9 +570,6 @@ void adc_buffer_full_interrupt() {
   // Invalidates CPU cache for adc_buffer_curr_half to ensure CPU sees the latest data written by DMA (RAM2 is cacheable):
   arm_dcache_delete((void *)adc_buffer_curr_half, sizeof(adc_buffer_curr_half));
 
-  // Uses Goertzel algorithm to analyze the frequency content of a full buffer of ADC samples:
-  // decode_single_bit_from_adc_window((const uint16_t*)adc_buffer_curr_half, buffer_size);
-
   // copy 1 window into RAM1 queue (fast) instead of calling decode_single_bit_from_adc_window
   if (rx_queue_count < 2) {
     memcpy(rx_win_q[rx_queue_write_index],

--- a/firmware/src/comm.cpp
+++ b/firmware/src/comm.cpp
@@ -24,16 +24,6 @@
 static void (*deliver_fn_override)(const char*) = nullptr;
 #endif
 
-// For debugging only:
-inline void pulse_begin() { digitalWriteFast(1, HIGH); }
-inline void pulse_end()   { digitalWriteFast(1, LOW); }
-
-// Temp changes to log sampling rate:
-// start changes---------------------------------------------------
-volatile uint32_t buffer_count = 0;
-uint32_t start_time_us = 0;
-// end changes-----------------------------------------------------
-
 // ------------------------------------------------------------------
 // State
 // ------------------------------------------------------------------
@@ -56,6 +46,17 @@ const uint32_t buffer_size = 410;
 #else
 static const uint32_t buffer_size = 410;
 #endif
+
+static const int WINDOWS_PER_BIT = 2;
+static const float MIN_TONE_MAGNITUDE = 1.0f; // Update value later with more testing
+
+// 2-window queue in RAM1 (DTCM). Each window is one 5ms window (410 samples).
+static uint16_t rx_win_q[WINDOWS_PER_BIT][buffer_size];
+
+static volatile uint8_t rx_queue_write_index = 0;
+static volatile uint8_t rx_queue_read_index = 0;
+static volatile uint8_t rx_queue_count = 0;
+static volatile bool rx_queue_overrun = false;
 
 // Holds one pair of Goertzel magnitudes:
 // Every time G runs, it gives a magnitude for each of the 2 frequencies we're checking
@@ -103,7 +104,7 @@ static uint8_t adc_window_counter = 0;
 
 // An array that will store state for the Goertzel algo - each goertzel_state obj
 // holds data to compute G algo for that frequency:
-static const uint8_t gs_len = 10;
+static const uint8_t gs_len = 2;   // only 2 bins: 2.0 kHz and 2.2 kHz
 goertzel_state gs[gs_len];
 
 // Charge amplifier gain:
@@ -111,8 +112,8 @@ static const int adg728_i2c_address = 76;
 
 // For get_bit_from_top_frequency:
 static const int MAX_BITS = 256;
-static uint8_t bitstream[MAX_BITS];
-static int bit_index = 0;
+static uint8_t window_stream[MAX_BITS * WINDOWS_PER_BIT];
+static int window_index = 0;
 static const float MAGNITUDE_THRESHOLD = 5.0f; // TODO: adjust as needed based on testing
 
 // Packet framing bytes:
@@ -125,48 +126,9 @@ static const uint8_t PACKET_END2   = 0x04;
 // For preamble:
 static const uint16_t PREAMBLE_BITS = 35; // unit is bits. 35 bits * 10 ms = 350 ms total preamble length
 
-// Plotting amplitude values:
-// Since these are updated within an interrupt, made these volatile-qualified to ensure the compiler is reading/writing these directly to/from memory instead of to/from a CPU register with potentially outdated data:
-volatile float curr_mag_2kHz = 0.0;
-volatile float curr_mag_2_2kHz = 0.0;
-volatile bool mag_ready = false;
-
 // ------------------------------------------------------------------
 // Functions
 // ------------------------------------------------------------------
-
-// Testing only------------------------------------------------------
-// Decide: 1, 0, or SILENCE based on Goertzel magnitudes
-enum Symbol { SYM_0, SYM_1, SYM_SILENCE };
-
-static inline Symbol decide_symbol(float P0, float P1) {
-  // 1) Energy gate (silence)
-  const float E = P0 + P1;                // total energy in this window
-  static float noise_ema = 0.0f;
-  if (noise_ema == 0.0f) noise_ema = E;   // init
-  // track floor only when low energy so strong tones don't raise it
-  if (E < noise_ema * 1.5f) noise_ema = 0.95f*noise_ema + 0.05f*E;
-
-  const float ABS_FLOOR = 0.1f;   // was 200.0f
-  const float THRESH    = fmaxf(ABS_FLOOR, noise_ema * 3.0f);
-  if (E < THRESH) return SYM_SILENCE;
-
-  // 2) Dominance gate (avoid random argmax in noise)
-  const float maxmag = (P1 > P0) ? P1 : P0;
-  const float minmag = (P1 > P0) ? P0 : P1;
-  const float MIN_DOM_RATIO = 0.3f;  // was 1.6f
-  if (maxmag < MIN_DOM_RATIO * minmag) return SYM_SILENCE;
-
-  // 3) Decide bit
-  return (P1 > P0) ? SYM_1 : SYM_0;
-}
-// End testing only--------------------------------------------------
-
-static inline void update_magnitudes_to_plot(float mag_2_kHz, float mag_2_2_kHz) {
-  curr_mag_2kHz = mag_2_kHz;
-  curr_mag_2_2kHz = mag_2_2_kHz;
-  mag_ready = true;
-}
 
 /**
  * Sends a 24‑bit SPI frame to the DAC: [addr/ctrl (8)] + [data (16)].
@@ -400,16 +362,35 @@ static void find_bit_boundaries(void) {
 }
 
 /**
+ *
+ */
+static void reset_receiver_state() {
+  noInterrupts();
+  rx_queue_write_index = rx_queue_read_index = rx_queue_count = 0;
+  rx_queue_overrun = false;
+  interrupts();
+
+  window_index = 0;
+
+  bit_boundaries_are_known = false;
+  bit_alignment_phase = 0;
+  have_enough_windows = false;
+  windows_collected = 0;
+  consecutive_weak_windows = 0;
+
+  window_history_index = 0;
+  goertzel_history_circ_buffer_index = 0;
+}
+
+/**
  * Computes Goertzel magnitudes for 2.0 kHz and 2.2 kHz, logs them, and (if signal is strong enough)
- * appends 0/1 to bitstream based on which bin is larger.
+ * appends 0/1 to window_stream based on which bin is larger.
  * Uses MAGNITUDE_THRESHOLD on (mag_2kHz + mag_2_2kHz) to suppress noise.
  */
 void get_bit_from_top_frequency() {
   // Calculates the magnitude of the complex output for each frequency bin:
   float mag_2kHz = sqrtf(powf(gs[0].y_re, 2) + powf(gs[0].y_im, 2));
   float mag_2_2kHz = sqrtf(powf(gs[1].y_re, 2) + powf(gs[1].y_im, 2));
-
-  update_magnitudes_to_plot(mag_2kHz, mag_2_2kHz);
 
   // Stores magnitudes in circ buffer for later analysis:
   goertzel_history_circ_buffer[goertzel_history_circ_buffer_index] = { mag_2kHz, mag_2_2kHz };
@@ -431,97 +412,98 @@ void get_bit_from_top_frequency() {
   find_bit_boundaries();
 
   // If boundaries aren’t established yet, stop here (only magnitudes logged this window):
-  if (!bit_boundaries_are_known) return;
-  else {
-    // Boundaries are known → keep monitoring average strength:
-    float avg_mag_lock = average_window_magnitude(ALIGNMENT_IDENTIFYING_G_OUTPUTS);
-    if (avg_mag_lock < MAGNITUDE_THRESHOLD) {
-      if (++consecutive_weak_windows >= MAX_WEAK_WINDOWS) {
-        // Signal stayed weak too long → reset state:
-        bit_boundaries_are_known = false;
-        consecutive_weak_windows = 0;
-        have_enough_windows = false;
-        windows_collected = 0;
-        return; // don't need to proceed with trying to append a bit at this point
-      }
-    } else {
+  if (!bit_boundaries_are_known) {
+    return;
+  }
+
+  // Boundaries are known → keep monitoring average strength:
+  float avg_mag_lock = average_window_magnitude(ALIGNMENT_IDENTIFYING_G_OUTPUTS);
+  if (avg_mag_lock < MAGNITUDE_THRESHOLD) {
+    if (++consecutive_weak_windows >= MAX_WEAK_WINDOWS) {
+      // Signal stayed weak too long → reset state:
+      bit_boundaries_are_known = false;
       consecutive_weak_windows = 0;
+      have_enough_windows = false;
+      windows_collected = 0;
+      reset_receiver_state();
+      return; // don't need to proceed with trying to append a bit at this point
     }
+  } else {
+    consecutive_weak_windows = 0;
   }
 
-  uint8_t bit = (mag_2_2kHz > mag_2kHz) ? 1 : 0;
-  if (bit_index < MAX_BITS) {
-    bitstream[bit_index++] = bit;
-    if (bit == 0) {
-      Serial.print("bit 0: ");
-    } else {
-      Serial.print("bit 1: ");
-    }
-    Serial.println(bit);
+  uint8_t bit_guess = (mag_2_2kHz > mag_2kHz) ? 1 : 0;
 
+  if (window_index < (MAX_BITS * WINDOWS_PER_BIT)) {
+    window_stream[window_index++] = bit_guess;
+  } else {
+    reset_receiver_state();
+    return;
   }
+
 }
 
 /**
- * Reassembles bytes MSB‑first from bitstream[], searches for 2‑byte header/footer,
+ * Reassembles bytes MSB‑first from window_stream[], searches for 2‑byte header/footer,
  * copies the payload to a C‑string, delivers it, then resets the bit buffer.
  * Header: PACKET_START1, PACKET_START2. Footer: PACKET_END1, PACKET_END2.
  */
-void check_for_complete_packet() {
-  // Buffer to hold reconstructed bytes from the bitstream:
+ void check_for_complete_packet() {
+  // Buffer to hold reconstructed bytes from the window_stream:
   static char decoded_bytes[MAX_PACKET_SIZE];
 
-  // Tracks how many full bytes have been reconstructed from the incoming bitstream[]:
-  int byte_count = 0;
+  for (int off = 0; off < 16; off++) {
+    // Tracks how many full bytes have been reconstructed from the incoming window_stream[]:
+    int byte_count = 0;
 
-  // Converts bitstream[] into bytes and stores in decoded_bytes:
-  for (int i = 0; i + 7 < bit_index; i += 8) {
-    uint8_t byte = 0;
-    for (int b = 0; b < 8; b++) {
-      byte = (byte << 1) | bitstream[i + b];
+    // decode bytes starting at this offset
+    for (int i = off; i + 15 < window_index; i += 16) {
+      uint8_t byte = 0;
+      for (int b = 0; b < 8; b++) {
+        uint8_t bit = window_stream[i + WINDOWS_PER_BIT * b];
+        byte = (byte << 1) | bit;
+      }
+      if (byte_count < MAX_PACKET_SIZE) decoded_bytes[byte_count++] = (char)byte;
     }
-    // Stores the byte if there's space:
-    if (byte_count < MAX_PACKET_SIZE) {
-      decoded_bytes[byte_count++] = byte;
+
+    // Scans for packet start (header):
+    int start = -1;
+    for (int i = 0; i + 1 < byte_count; i++) {
+      if ((uint8_t)decoded_bytes[i] == PACKET_START1 &&
+          (uint8_t)decoded_bytes[i + 1] == PACKET_START2) {
+        start = i + 2;
+        break;
+      }
     }
+    if (start == -1) continue;   // <- was return
+
+    // Scans for packet end (footer):
+    int end = -1;
+    for (int i = start; i < byte_count - 1; i++) {
+      if ((uint8_t)decoded_bytes[i] == PACKET_END1 &&
+          (uint8_t)decoded_bytes[i + 1] == PACKET_END2) {
+        end = i;
+        break;
+      }
+    }
+    if (end == -1) continue;     // <- was return
+
+    int msg_len = end - start;
+    if (msg_len <= 0 || msg_len >= MAX_TEXT_LENGTH) continue;
+
+    char message[MAX_TEXT_LENGTH];
+    memcpy(message, &decoded_bytes[start], msg_len);
+    message[msg_len] = '\0';
+
+    // Adds message to chat history and displays it:
+    deliver_message(message);
+
+    // Resets bit buffer:
+    window_index = 0;
+
+    return; // success case
   }
-
-  // Scans for packet start (header):
-  int start = -1;
-  for (int i = 0; i < byte_count - 3; i++) {
-    if ((uint8_t)decoded_bytes[i] == PACKET_START1 &&
-        (uint8_t)decoded_bytes[i + 1] == PACKET_START2) {
-      start = i + 2;
-      break;
-    }
-  }
-  // No valid header found, so return early:
-  if (start == -1) return;
-
-  // Scans for packet end (footer):
-  int end = -1;
-  for (int i = start; i < byte_count - 1; i++) {
-    if ((uint8_t)decoded_bytes[i] == PACKET_END1 &&
-        (uint8_t)decoded_bytes[i + 1] == PACKET_END2) {
-      end = i;
-      break;
-    }
-  }
-  // No valid footer found, so return early:
-  if (end == -1) return;
-
-  // Copies message content into null-terminated string:
-  char message[MAX_TEXT_LENGTH];
-  int msg_len = end - start;
-  if (msg_len >= MAX_TEXT_LENGTH) msg_len = MAX_TEXT_LENGTH - 1;
-  strncpy(message, &decoded_bytes[start], msg_len);
-  message[msg_len] = '\0';
-
-  // Adds message to chat history and displays it:
-  deliver_message(message);
-
-  // Resets bit buffer:
-  bit_index = 0;
+  // If here: tried all offsets, nothing valid found
 }
 
 /**
@@ -545,14 +527,10 @@ void for_each_goertzel_state(void (*one_param_fn)(goertzel_state*), void (*two_p
 
 /**
  * Processes one ADC window at bit-aligned intervals:
- * runs Goertzel, extracts a bit, appends it to the bitstream, checks for a complete packet, then resets Goertzel state.
+ * runs Goertzel, extracts a bit, appends it to the window_stream, checks for a complete packet, then resets Goertzel state.
  */
 void decode_single_bit_from_adc_window(const uint16_t* samples, size_t size) {
-  uint8_t curr_phase = adc_window_counter++ % SCAN_CHAIN_LENGTH;
-
-  // If we know for sure the current window is out of phase, don't bother
-  // with processing it:
-  if (bit_boundaries_are_known && curr_phase != bit_alignment_phase) return;
+  adc_window_counter++;
 
   // Feeds each ADC sample into the Goertzel filters:
   for (size_t i = 0; i < size; i++) {
@@ -561,6 +539,15 @@ void decode_single_bit_from_adc_window(const uint16_t* samples, size_t size) {
 
   // Computes this window’s frequency results:
   for_each_goertzel_state(finalize_goertzel, NULL, -1);
+
+  float mag0 = sqrtf(gs[0].y_re * gs[0].y_re + gs[0].y_im * gs[0].y_im);
+  float mag1 = sqrtf(gs[1].y_re * gs[1].y_re + gs[1].y_im * gs[1].y_im);
+  if (mag0 < MIN_TONE_MAGNITUDE) {
+    if (mag1 < MIN_TONE_MAGNITUDE) {
+      for_each_goertzel_state(reset_goertzel, NULL, -1);
+      return;
+    }
+  }
 
   get_bit_from_top_frequency();
   check_for_complete_packet();
@@ -577,33 +564,54 @@ void decode_single_bit_from_adc_window(const uint16_t* samples, size_t size) {
  * two buffers correspond to one bit period, and adc_buffer_full_interrupt() fires every 5 ms.
  */
 void adc_buffer_full_interrupt() {
-  pulse_begin();
-
   // Clears the DMA interrupt flag so it's ready for the next transfer:
   dma_ch1.clearInterrupt();
-
-  // Temp changes to log sampling rate:
-  // start changes---------------------------------------------------
-  buffer_count++;
-  // end changes-----------------------------------------------------
-
-  // Temp changes to log how many samples in buffer:
-  // start changes---------------------------------------------------
-  // static uint32_t total_samples = 0;
-  // total_samples += buffer_size;  // how many samples DMA says it just finished
-  // Serial.printf("DMA complete: total_samples=%lu\n", total_samples); // should increase by +410 each time
-  // end changes-----------------------------------------------------
 
   // Invalidates CPU cache for adc_buffer_curr_half to ensure CPU sees the latest data written by DMA (RAM2 is cacheable):
   arm_dcache_delete((void *)adc_buffer_curr_half, sizeof(adc_buffer_curr_half));
 
   // Uses Goertzel algorithm to analyze the frequency content of a full buffer of ADC samples:
-  decode_single_bit_from_adc_window((const uint16_t*)adc_buffer_curr_half, buffer_size);
+  // decode_single_bit_from_adc_window((const uint16_t*)adc_buffer_curr_half, buffer_size);
+
+  // copy 1 window into RAM1 queue (fast) instead of calling decode_single_bit_from_adc_window
+  if (rx_queue_count < 2) {
+    memcpy(rx_win_q[rx_queue_write_index],
+           (const void*)adc_buffer_curr_half,
+           sizeof(rx_win_q[0]));
+    rx_queue_write_index = (rx_queue_write_index + 1) & 1;
+    rx_queue_count++;
+  } else {
+    rx_queue_overrun = true; // dropped a window because loop couldn't keep up
+  }
 
   // Re-enables the DMA channel for next read:
   dma_ch1.enable();
+}
 
-  pulse_end();
+/**
+ * Drains the ADC/DMA RX queue and converts each queued sample window into bits.
+ * Periodically checks whether the accumulated bits form a complete packet/message.
+ */
+void process_rx_windows() {
+  static uint8_t scan_div = 0;
+
+  while (true) {
+    uint8_t slot;
+
+    noInterrupts();
+    if (rx_queue_count == 0) { interrupts(); break; }
+    slot = rx_queue_read_index;
+    rx_queue_read_index = (rx_queue_read_index + 1) & 1;
+    rx_queue_count--;
+    interrupts();
+
+    decode_single_bit_from_adc_window(rx_win_q[slot], buffer_size);
+
+    if (++scan_div >= 16) {
+      scan_div = 0;
+      check_for_complete_packet();
+    }
+  }
 }
 
 /**
@@ -629,7 +637,6 @@ void setup_receiver() {
   adc->adc0->setAveraging(1); // no averaging
   adc->adc0->setResolution(12); // bits
   adc->adc0->setConversionSpeed(ADC_CONVERSION_SPEED::HIGH_SPEED);
-  //adc->adc0->setSamplingSpeed(ADC_SAMPLING_SPEED::HIGH_SPEED);
 
   // Configures DMA to transfer ADC samples into adc_buffer_curr_half:
   // Note: The following line may raise a compiler warning because type-punning ADC1_R0 here violates strict aliasing rules, but can be safely ignored
@@ -664,12 +671,12 @@ void setup_receiver() {
 // ------------------------------------------------------------------
 #ifdef UNIT_TEST
 
-uint8_t* _test_get_bitstream() {
-  return bitstream;
+uint8_t* _test_get_window_stream() {
+  return window_stream;
 }
 
-int* _test_get_bit_index() {
-  return &bit_index;
+int* _test_get_window_index() {
+  return &window_index;
 }
 
 goertzel_state* _test_get_goertzel_state() {

--- a/firmware/src/keyboard.cpp
+++ b/firmware/src/keyboard.cpp
@@ -148,7 +148,6 @@ void poll_keyboard(ChatBufferState* state) {
           char key = KEYBOARD_LAYOUT[key_index];
           tx_display_buffer[tx_display_buffer_length] = key;
           tx_display_buffer_length++;
-          // Serial.printf("Read buffer %ul\n", ~read_buffer);
           Serial.printf("You pressed key_index=%d, key=\'%c\'\n", key_index, key);
           redraw_typing_box();
           // modifier = 0; // reset modifier keys

--- a/firmware/src/keyboard.cpp
+++ b/firmware/src/keyboard.cpp
@@ -24,8 +24,6 @@ static IntervalTimer keyboard_poller_timer;
 // => 64 key states, i.e. 1 for pressed, 0 for not:
 static volatile uint64_t switch_state;
 
-static const unsigned long screen_timeout_ms = 15000;
-
 // Useful for debouncing/long presses:
 static uint32_t time_of_last_press_ms;
 
@@ -153,7 +151,7 @@ void poll_keyboard(ChatBufferState* state) {
           // modifier = 0; // reset modifier keys
       }
     }
-  } else if (screen_on && millis() - time_of_last_press_ms > screen_timeout_ms) {
+  } else if (screen_on && millis() - time_of_last_press_ms > SCREEN_TIMEOUT_MS) {
     screen_on = false;
     digitalWrite(tft_led_pin, LOW);
   }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -44,10 +44,10 @@ void setup() {
 
 void loop() {
   // Runs once per bit analysis window (so every 5 ms, when get_bit_from_top_frequency() updates the magnitudes):
-  // if (mag_ready) {
-  //   mag_ready = false;  // Clears the flag so we only print once
-  //   Serial.println(curr_mag_2kHz + curr_mag_2_2kHz);
-  // }
+  if (mag_ready) {
+    mag_ready = false;  // Clears the flag so we only print once
+   // Serial.println(curr_mag_2kHz + curr_mag_2_2kHz);
+  }
 
   // poll_battery();
 }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -16,17 +16,12 @@
 
 #ifndef UNIT_TEST
 
-// Temp changes to log sampling rate:
-// start changes---------------------------------------------------
-extern volatile uint32_t buffer_count;
-// end changes-----------------------------------------------------
-
 void setup() {
   Serial.begin(9600);
+
   // Checks if connection is working and waits up to 5 sec for it to happen:
   while (!Serial && millis() < 5000) ;
   delay(100);
-  Serial.println("============================\nStarting setup()");
 
   // SPI commuincation bus for keyboard/display etc:
   SPI.begin();
@@ -35,37 +30,18 @@ void setup() {
   // Specifies 12-bit resolution:
   analogReadResolution(12);
 
-  // Testing purposes only:
-  test_incoming_message.begin(incoming_message_callback, 1000000);
+  // Testing purposes only (disabled while testing receiving logic):
+  // test_incoming_message.begin(incoming_message_callback, 1000000);
 
   // Module setup:
   setup_screen();
   setup_receiver();
   setup_transmitter();
   setup_keyboard_poller();
-
-  Serial.println("setup() complete\n============================");
 }
 
 void loop() {
-  // Runs once per bit analysis window (so every 5 ms, when get_bit_from_top_frequency() updates the magnitudes):
-  // if (mag_ready) {
-  //   mag_ready = false;  // Clears the flag so we only print once
-  //   Serial.println(curr_mag_2kHz + curr_mag_2_2kHz);
-  // }
-
-  // Temp changes to log sampling rate:
-  // start changes---------------------------------------------------
-  static uint32_t start_time_us = 0;
-  if (start_time_us == 0) start_time_us = micros();
-  if (micros() - start_time_us >= 1000000) {  // 1 second
-    uint32_t count = buffer_count;
-    buffer_count = 0;
-    start_time_us = micros();
-    Serial.printf("Actual sample rate ≈ %lu samples/sec\n", count * 410);
-
-  }
-  // end changes-----------------------------------------------------
+  process_rx_windows();
 
   // poll_battery();
 }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -49,7 +49,7 @@ void loop() {
     Serial.println(curr_mag_2kHz + curr_mag_2_2kHz);
   }
 
-  poll_battery();
+  // poll_battery();
 }
 
 #endif

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -16,6 +16,11 @@
 
 #ifndef UNIT_TEST
 
+// Temp changes to log sampling rate:
+// start changes---------------------------------------------------
+extern volatile uint32_t buffer_count;
+// end changes-----------------------------------------------------
+
 void setup() {
   Serial.begin(9600);
   // Checks if connection is working and waits up to 5 sec for it to happen:
@@ -44,10 +49,23 @@ void setup() {
 
 void loop() {
   // Runs once per bit analysis window (so every 5 ms, when get_bit_from_top_frequency() updates the magnitudes):
-  if (mag_ready) {
-    mag_ready = false;  // Clears the flag so we only print once
-   // Serial.println(curr_mag_2kHz + curr_mag_2_2kHz);
+  // if (mag_ready) {
+  //   mag_ready = false;  // Clears the flag so we only print once
+  //   Serial.println(curr_mag_2kHz + curr_mag_2_2kHz);
+  // }
+
+  // Temp changes to log sampling rate:
+  // start changes---------------------------------------------------
+  static uint32_t start_time_us = 0;
+  if (start_time_us == 0) start_time_us = micros();
+  if (micros() - start_time_us >= 1000000) {  // 1 second
+    uint32_t count = buffer_count;
+    buffer_count = 0;
+    start_time_us = micros();
+    Serial.printf("Actual sample rate ≈ %lu samples/sec\n", count * 410);
+
   }
+  // end changes-----------------------------------------------------
 
   // poll_battery();
 }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -17,7 +17,6 @@
 #ifndef UNIT_TEST
 
 void setup() {
-  // Initializes serial communication with Teensy at baud rate of 9600 bps:
   Serial.begin(9600);
   // Checks if connection is working and waits up to 5 sec for it to happen:
   while (!Serial && millis() < 5000) ;
@@ -44,7 +43,11 @@ void setup() {
 }
 
 void loop() {
-  // uint16_t val = 2048 + 2047 * sin(2*3.14159*micros()/1e6 * 1.5e3);
+  // Runs once per bit analysis window (so every 5 ms, when get_bit_from_top_frequency() updates the magnitudes):
+  if (mag_ready) {
+    mag_ready = false;  // Clears the flag so we only print once
+    Serial.println(curr_mag_2kHz + curr_mag_2_2kHz);
+  }
 
   poll_battery();
 }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,6 +1,6 @@
 // ==================================================================
 // main.cpp
-// Entry point: initializes all modules and runs main event loop
+// Arduino entry point: initializes modules in setup() and runs loop()
 // ==================================================================
 #include <SPI.h>
 #include <Wire.h>
@@ -19,21 +19,21 @@
 void setup() {
   Serial.begin(9600);
 
-  // Checks if connection is working and waits up to 5 sec for it to happen:
+  // Waits up to 5s for the Serial connection (USB) to become available
   while (!Serial && millis() < 5000) ;
   delay(100);
 
-  // SPI commuincation bus for keyboard/display etc:
+  // SPI bus init (keyboard/display/etc.)
   SPI.begin();
-  // I2C communication bus for charge amplifier:
+  // I2C bus init (charge amplifier)
   Wire.begin();
-  // Specifies 12-bit resolution:
+  // Sets ADC read resolution to 12-bit
   analogReadResolution(12);
 
-  // Testing purposes only (disabled while testing receiving logic):
+  // Testing only: timer-driven simulated incoming messages (currently disabled)
   // test_incoming_message.begin(incoming_message_callback, 1000000);
 
-  // Module setup:
+  // Module init
   setup_screen();
   setup_receiver();
   setup_transmitter();
@@ -43,6 +43,7 @@ void setup() {
 void loop() {
   process_rx_windows();
 
+  // Disabled: seems to interfere with RX/decoding timing; revisit/verify interaction with receiving logic
   // poll_battery();
 }
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -44,10 +44,10 @@ void setup() {
 
 void loop() {
   // Runs once per bit analysis window (so every 5 ms, when get_bit_from_top_frequency() updates the magnitudes):
-  if (mag_ready) {
-    mag_ready = false;  // Clears the flag so we only print once
-    Serial.println(curr_mag_2kHz + curr_mag_2_2kHz);
-  }
+  // if (mag_ready) {
+  //   mag_ready = false;  // Clears the flag so we only print once
+  //   Serial.println(curr_mag_2kHz + curr_mag_2_2kHz);
+  // }
 
   // poll_battery();
 }

--- a/firmware/test/mock_display.cpp
+++ b/firmware/test/mock_display.cpp
@@ -1,7 +1,7 @@
 // ==================================================================
 // mock_display.cpp
 // Provides a mock implementations from display.cpp
-// for unit testing deliver_message, parse_message, etc.
+// for unit testing deliver_message, check_for_complete_packet, etc.
 // ==================================================================
 #include "chat_logic.h"
 

--- a/firmware/test/receiving/test_adc_buffer_full_interrupt/adc_buffer_full_interrupt.cpp
+++ b/firmware/test/receiving/test_adc_buffer_full_interrupt/adc_buffer_full_interrupt.cpp
@@ -3,7 +3,7 @@
 // Input: Filled ADC DMA buffer with sampled data
 // Output: ISR queues windows; process_rx_windows() drains queue and appends bits to window_stream
 // Run just this test with:
-//   pio test -e teensy40_test -f "receiving/test_adc_buffer_full_interrupt"
+//  pio test -e teensy40_test -f "receiving/test_adc_buffer_full_interrupt"
 // ==================================================================
 #include <Arduino.h>
 #include <unity.h>

--- a/firmware/test/receiving/test_adc_buffer_full_interrupt/adc_buffer_full_interrupt.cpp
+++ b/firmware/test/receiving/test_adc_buffer_full_interrupt/adc_buffer_full_interrupt.cpp
@@ -8,11 +8,26 @@
 #include <unity.h>
 
 #include "comm.h"
+#include "goertzel.h"
+
+static void prime_alignment_with_alternating_windows() {
+  const float sr = 81920.0f, amp = 2047.0f, off = 2048.0f;
+  volatile uint16_t* buf = _test_get_adc_buffer_curr_half();
+  for (int w = 0; w < 7; ++w) {                 // need 7 recent windows
+    float f = (w % 2 == 0) ? 2000.0f : 2200.0f; // 0,1,0,1,... for lock
+    for (uint32_t i = 0; i < buffer_size; ++i) {
+      float t = (float)i / sr;
+      buf[i] = (uint16_t)(off + amp * sinf(2.0f * PI * f * t));
+    }
+    arm_dcache_flush((void*)buf, sizeof(uint16_t) * buffer_size);
+    adc_buffer_full_interrupt();
+  }
+}
 
 // Helper to fill DMA buffer:
 void fill_dma_buffer(uint16_t value, bool alternate_values = false) {
   volatile uint16_t* dma_buf = _test_get_adc_buffer_curr_half();
-  for (size_t i = 0; i < buffer_size * 2; i++) {
+  for (size_t i = 0; i < buffer_size; i++) {
     dma_buf[i] = alternate_values ? ((i % 2 == 0) ? 0 : value) : value;
   }
   // Flushes CPU cache for adc_buffer_curr_half to ensure all written values are committed to RAM2.
@@ -20,20 +35,8 @@ void fill_dma_buffer(uint16_t value, bool alternate_values = false) {
   arm_dcache_flush((void*)dma_buf, sizeof(uint16_t) * buffer_size);
 }
 
-// Helper to clear adc_buffer_full_bit:
-void clear_adc_buffer_full_bit	() {
-  uint16_t* copy = _test_get_adc_buffer_full_bit	();
-  for (size_t i = 0; i < buffer_size * 2; i++) {
-    copy[i] = 0;
-  }
-}
-
 void setUp(void) {
-  // Fills adc_buffer_curr_half with known test data:
-  fill_dma_buffer(1234);
-
-  // Gets pointer to adc_buffer_full_bit and zeroes it out:
-  clear_adc_buffer_full_bit	();
+  fill_dma_buffer(0);
 
   // Resets bit index:
   *_test_get_bit_index() = 0;
@@ -41,55 +44,43 @@ void setUp(void) {
   // Resets adc_window_counter so decode will actually run:
   *_test_get_adc_window_counter() = 0;
 
-  // Provides expected Goertzel outputs for bit extraction:
+  // Initialize Goertzel states so magnitude math is valid in tests
   goertzel_state* gs = _test_get_goertzel_state();
-  gs[1].y_re = 10; gs[1].y_im = 0;  // Strong freq 1
-  gs[0].y_re = 0;  gs[0].y_im = 0;  // No freq 0
-
+  initialize_goertzel(&gs[0], 2000, 81920);  // 2.0 kHz
+  initialize_goertzel(&gs[1], 2200, 81920);  // 2.2 kHz
 }
 
 void tearDown(void) {}
 
-void test_buffer_copy(void) {
-  adc_buffer_full_interrupt();
-  adc_buffer_full_interrupt();
-
-  // Confirsm adc_buffer_full_bit matches adc_buffer_curr_half (1234 pattern):
-  uint16_t* copy = _test_get_adc_buffer_full_bit	();
-  for (size_t i = 0; i < buffer_size * 2; i++) {
-    TEST_ASSERT_EQUAL(1234, copy[i]);
-  }
-}
-
 void test_bit_extraction_triggered(void) {
+  prime_alignment_with_alternating_windows();
+
   // Fills both halves with a strong sine wave:
   float frequency = 2200.0f;
   float sampling_rate = 81920.0f;
   float amplitude = 2047.0f;
   float offset = 2048.0f;
 
-  uint16_t* half1 = _test_get_adc_buffer_prev_half();
-  volatile uint16_t* half2 = _test_get_adc_buffer_curr_half();
+  volatile uint16_t* curr_half = _test_get_adc_buffer_curr_half();
 
   for (uint32_t i = 0; i < buffer_size; i++) {
     float t = (float)i / sampling_rate;
     float sine = sinf(2.0f * PI * frequency * t);
-    half1[i] = (uint16_t)(offset + amplitude * sine);
-    half2[i] = (uint16_t)(offset + amplitude * sine);
+    curr_half[i] = (uint16_t)(offset + amplitude * sine);
   }
-
+  arm_dcache_flush((void*)curr_half, sizeof(uint16_t) * buffer_size);
   adc_buffer_full_interrupt();
 
-  // Fills half2 again to simulate new DMA buffer:
+  // Fills curr_half again to simulate new DMA buffer:
   for (uint32_t i = 0; i < buffer_size; i++) {
     float t = (float)i / sampling_rate;
     float sine = sinf(2.0f * PI * frequency * t);
-    half2[i] = (uint16_t)(offset + amplitude * sine);
+    curr_half[i] = (uint16_t)(offset + amplitude * sine);
   }
   // Flushes CPU cache after manually updating adc_buffer_curr_half again.
   // Required because RAM2 is cacheable — without this, adc_buffer_full_interrupt()
   // might read stale data from RAM instead of the updated values:
-  arm_dcache_flush((void*)half2, sizeof(uint16_t) * buffer_size);
+  arm_dcache_flush((void*)curr_half, sizeof(uint16_t) * buffer_size);
 
   adc_buffer_full_interrupt();
 
@@ -98,29 +89,41 @@ void test_bit_extraction_triggered(void) {
 
 void test_adc_buffer_with_silence_does_not_append_bit(void) {
   fill_dma_buffer(0);
-  clear_adc_buffer_full_bit	();
+
+  // Disarm any prior state (feed several weak windows to clear history)
+  for (int i = 0; i < 6; ++i) {  // 6 is enough regardless of scan length
+    adc_buffer_full_interrupt();
+  }
+  // Now start fresh for this assertion
+  *_test_get_bit_index() = 0;
+  *_test_get_adc_window_counter() = 0;
 
   adc_buffer_full_interrupt();
   adc_buffer_full_interrupt();
 
-  uint16_t* copy = _test_get_adc_buffer_full_bit	();
-  for (size_t i = 0; i < buffer_size * 2; i++) {
+  uint16_t* copy = (uint16_t*)_test_get_adc_buffer_curr_half();
+  for (size_t i = 0; i < buffer_size; i++) {
     TEST_ASSERT_EQUAL(0, copy[i]);
   }
 
-  TEST_ASSERT_EQUAL(0, *_test_get_bit_index());
+  int idx = *_test_get_bit_index();
+  uint8_t* bits = _test_get_bitstream();
+
+  // Silence may append zero-bits; it must not produce any '1's.
+  for (int i = 0; i < idx; ++i) {
+    TEST_ASSERT_EQUAL(0, bits[i]);
+  }
 }
 
 void test_buffer_copy_max_values(void) {
+  prime_alignment_with_alternating_windows();
+  uint16_t* copy = (uint16_t*)_test_get_adc_buffer_curr_half();
   fill_dma_buffer(UINT16_MAX);
-  clear_adc_buffer_full_bit	();
-
   adc_buffer_full_interrupt();
   adc_buffer_full_interrupt();
 
   // Confirms adc_buffer_full_bit	matches max pattern:
-  uint16_t* copy = _test_get_adc_buffer_full_bit	();
-  for (size_t i = 0; i < buffer_size * 2; i++) {
+  for (size_t i = 0; i < buffer_size; i++) {
     TEST_ASSERT_EQUAL(UINT16_MAX, copy[i]);
   }
 
@@ -129,15 +132,14 @@ void test_buffer_copy_max_values(void) {
 }
 
 void test_buffer_copy_alternating(void) {
+  prime_alignment_with_alternating_windows();
+  uint16_t* copy = (uint16_t*)_test_get_adc_buffer_curr_half();
   fill_dma_buffer(UINT16_MAX, true);
-  clear_adc_buffer_full_bit	();
-
   adc_buffer_full_interrupt();
   adc_buffer_full_interrupt();
 
   // Confirms adc_buffer_full_bit matches alternating pattern:
-  uint16_t* copy = _test_get_adc_buffer_full_bit();
-  for (size_t i = 0; i < buffer_size * 2; i++) {
+  for (size_t i = 0; i < buffer_size; i++) {
     uint16_t expected = (i % 2 == 0) ? 0 : UINT16_MAX;
     TEST_ASSERT_EQUAL(expected, copy[i]);
   }
@@ -165,7 +167,6 @@ void setup() {
   while (!Serial && millis() < 5000);
 
   UNITY_BEGIN();
-  RUN_TEST(test_buffer_copy);
   RUN_TEST(test_bit_extraction_triggered);
   RUN_TEST(test_adc_buffer_with_silence_does_not_append_bit);
   RUN_TEST(test_buffer_copy_max_values);

--- a/firmware/test/receiving/test_adc_buffer_full_interrupt/adc_buffer_full_interrupt.cpp
+++ b/firmware/test/receiving/test_adc_buffer_full_interrupt/adc_buffer_full_interrupt.cpp
@@ -13,7 +13,7 @@
 
 static void fill_dma_with_sine(float frequency_hz) {
   const float sr = 81920.0f, amp = 2047.0f, off = 2048.0f;
-  volatile uint16_t* buf = _test_get_adc_buffer_curr_half();
+  volatile uint16_t* buf = _test_get_adc_dma_window();
 
   for (uint32_t i = 0; i < buffer_size; ++i) {
     float t = (float)i / sr;
@@ -25,7 +25,7 @@ static void fill_dma_with_sine(float frequency_hz) {
 }
 
 static void fill_dma_constant(uint16_t value) {
-  volatile uint16_t* buf = _test_get_adc_buffer_curr_half();
+  volatile uint16_t* buf = _test_get_adc_dma_window();
   for (uint32_t i = 0; i < buffer_size; ++i) buf[i] = value;
   arm_dcache_flush((void*)buf, sizeof(uint16_t) * buffer_size);
 }

--- a/firmware/test/receiving/test_adc_buffer_full_interrupt/adc_buffer_full_interrupt.cpp
+++ b/firmware/test/receiving/test_adc_buffer_full_interrupt/adc_buffer_full_interrupt.cpp
@@ -11,11 +11,11 @@
 
 // Helper to fill DMA buffer:
 void fill_dma_buffer(uint16_t value, bool alternate_values = false) {
-  volatile uint16_t* dma_buf = _test_get_adc_buffer_half_2();
+  volatile uint16_t* dma_buf = _test_get_adc_buffer_curr_half();
   for (size_t i = 0; i < buffer_size * 2; i++) {
     dma_buf[i] = alternate_values ? ((i % 2 == 0) ? 0 : value) : value;
   }
-  // Flushes CPU cache for adc_buffer_half_2 to ensure all written values are committed to RAM2.
+  // Flushes CPU cache for adc_buffer_curr_half to ensure all written values are committed to RAM2.
   // Without this, cached writes may not be visible to DMA or other code that reads from RAM:
   arm_dcache_flush((void*)dma_buf, sizeof(uint16_t) * buffer_size);
 }
@@ -29,7 +29,7 @@ void clear_adc_buffer_full_bit	() {
 }
 
 void setUp(void) {
-  // Fills adc_buffer_half_2 with known test data:
+  // Fills adc_buffer_curr_half with known test data:
   fill_dma_buffer(1234);
 
   // Gets pointer to adc_buffer_full_bit and zeroes it out:
@@ -54,7 +54,7 @@ void test_buffer_copy(void) {
   adc_buffer_full_interrupt();
   adc_buffer_full_interrupt();
 
-  // Confirsm adc_buffer_full_bit matches adc_buffer_half_2 (1234 pattern):
+  // Confirsm adc_buffer_full_bit matches adc_buffer_curr_half (1234 pattern):
   uint16_t* copy = _test_get_adc_buffer_full_bit	();
   for (size_t i = 0; i < buffer_size * 2; i++) {
     TEST_ASSERT_EQUAL(1234, copy[i]);
@@ -68,8 +68,8 @@ void test_bit_extraction_triggered(void) {
   float amplitude = 2047.0f;
   float offset = 2048.0f;
 
-  uint16_t* half1 = _test_get_adc_buffer_half_1();
-  volatile uint16_t* half2 = _test_get_adc_buffer_half_2();
+  uint16_t* half1 = _test_get_adc_buffer_prev_half();
+  volatile uint16_t* half2 = _test_get_adc_buffer_curr_half();
 
   for (uint32_t i = 0; i < buffer_size; i++) {
     float t = (float)i / sampling_rate;
@@ -86,7 +86,7 @@ void test_bit_extraction_triggered(void) {
     float sine = sinf(2.0f * PI * frequency * t);
     half2[i] = (uint16_t)(offset + amplitude * sine);
   }
-  // Flushes CPU cache after manually updating adc_buffer_half_2 again.
+  // Flushes CPU cache after manually updating adc_buffer_curr_half again.
   // Required because RAM2 is cacheable — without this, adc_buffer_full_interrupt()
   // might read stale data from RAM instead of the updated values:
   arm_dcache_flush((void*)half2, sizeof(uint16_t) * buffer_size);

--- a/firmware/test/receiving/test_adc_buffer_full_interrupt/adc_buffer_full_interrupt.cpp
+++ b/firmware/test/receiving/test_adc_buffer_full_interrupt/adc_buffer_full_interrupt.cpp
@@ -1,8 +1,9 @@
 // ==================================================================
 // adc_buffer_full_interrupt.cpp
 // Input: Filled ADC DMA buffer with sampled data
-// Output: Copies data for processing, triggers frequency analysis and bit extraction
-// Run just this test with $ pio test -e teensy40_test -f "receiving/test_adc_buffer_full_interrupt"
+// Output: ISR queues windows; process_rx_windows() drains queue and appends bits to window_stream
+// Run just this test with:
+//   pio test -e teensy40_test -f "receiving/test_adc_buffer_full_interrupt"
 // ==================================================================
 #include <Arduino.h>
 #include <unity.h>
@@ -10,39 +11,40 @@
 #include "comm.h"
 #include "goertzel.h"
 
-static void prime_alignment_with_alternating_windows() {
+static void fill_dma_with_sine(float frequency_hz) {
   const float sr = 81920.0f, amp = 2047.0f, off = 2048.0f;
   volatile uint16_t* buf = _test_get_adc_buffer_curr_half();
-  for (int w = 0; w < 7; ++w) {                 // need 7 recent windows
-    float f = (w % 2 == 0) ? 2000.0f : 2200.0f; // 0,1,0,1,... for lock
-    for (uint32_t i = 0; i < buffer_size; ++i) {
-      float t = (float)i / sr;
-      buf[i] = (uint16_t)(off + amp * sinf(2.0f * PI * f * t));
-    }
-    arm_dcache_flush((void*)buf, sizeof(uint16_t) * buffer_size);
-    adc_buffer_full_interrupt();
+
+  for (uint32_t i = 0; i < buffer_size; ++i) {
+    float t = (float)i / sr;
+    buf[i] = (uint16_t)(off + amp * sinf(2.0f * PI * frequency_hz * t));
   }
+
+  // RAM2 is cacheable; ensure CPU writes hit OCRAM before ISR reads it
+  arm_dcache_flush((void*)buf, sizeof(uint16_t) * buffer_size);
 }
 
-// Helper to fill DMA buffer:
-void fill_dma_buffer(uint16_t value, bool alternate_values = false) {
-  volatile uint16_t* dma_buf = _test_get_adc_buffer_curr_half();
-  for (size_t i = 0; i < buffer_size; i++) {
-    dma_buf[i] = alternate_values ? ((i % 2 == 0) ? 0 : value) : value;
+static void fill_dma_constant(uint16_t value) {
+  volatile uint16_t* buf = _test_get_adc_buffer_curr_half();
+  for (uint32_t i = 0; i < buffer_size; ++i) buf[i] = value;
+  arm_dcache_flush((void*)buf, sizeof(uint16_t) * buffer_size);
+}
+
+// Prime the receiver alignment by feeding alternating windows.
+// IMPORTANT: after each ISR call, drain via process_rx_windows() so the 2-window queue doesn't overrun.
+static void prime_alignment_with_alternating_windows() {
+  for (int w = 0; w < 7; ++w) { // needs 7 recent windows for boundary detection
+    float f = (w % 2 == 0) ? 2000.0f : 2200.0f;
+    fill_dma_with_sine(f);
+    adc_buffer_full_interrupt();
+    process_rx_windows();
   }
-  // Flushes CPU cache for adc_buffer_curr_half to ensure all written values are committed to RAM2.
-  // Without this, cached writes may not be visible to DMA or other code that reads from RAM:
-  arm_dcache_flush((void*)dma_buf, sizeof(uint16_t) * buffer_size);
 }
 
 void setUp(void) {
-  fill_dma_buffer(0);
-
-  // Resets bit index:
-  *_test_get_bit_index() = 0;
-
-  // Resets adc_window_counter so decode will actually run:
+  // Reset counters/streams used by tests
   *_test_get_adc_window_counter() = 0;
+  *_test_get_window_index() = 0;
 
   // Initialize Goertzel states so magnitude math is valid in tests
   goertzel_state* gs = _test_get_goertzel_state();
@@ -52,114 +54,55 @@ void setUp(void) {
 
 void tearDown(void) {}
 
-void test_bit_extraction_triggered(void) {
+void test_isr_queues_and_process_drains_one_window_into_window_stream(void) {
   prime_alignment_with_alternating_windows();
 
-  // Fills both halves with a strong sine wave:
-  float frequency = 2200.0f;
-  float sampling_rate = 81920.0f;
-  float amplitude = 2047.0f;
-  float offset = 2048.0f;
+  // Keep alignment state, but start the stream fresh for this assertion:
+  *_test_get_window_index() = 0;
 
-  volatile uint16_t* curr_half = _test_get_adc_buffer_curr_half();
-
-  for (uint32_t i = 0; i < buffer_size; i++) {
-    float t = (float)i / sampling_rate;
-    float sine = sinf(2.0f * PI * frequency * t);
-    curr_half[i] = (uint16_t)(offset + amplitude * sine);
-  }
-  arm_dcache_flush((void*)curr_half, sizeof(uint16_t) * buffer_size);
+  // Queue one strong "1" window (2200 Hz), then drain:
+  fill_dma_with_sine(2200.0f);
   adc_buffer_full_interrupt();
+  process_rx_windows();
 
-  // Fills curr_half again to simulate new DMA buffer:
-  for (uint32_t i = 0; i < buffer_size; i++) {
-    float t = (float)i / sampling_rate;
-    float sine = sinf(2.0f * PI * frequency * t);
-    curr_half[i] = (uint16_t)(offset + amplitude * sine);
-  }
-  // Flushes CPU cache after manually updating adc_buffer_curr_half again.
-  // Required because RAM2 is cacheable — without this, adc_buffer_full_interrupt()
-  // might read stale data from RAM instead of the updated values:
-  arm_dcache_flush((void*)curr_half, sizeof(uint16_t) * buffer_size);
+  int idx = *_test_get_window_index();
+  TEST_ASSERT_GREATER_OR_EQUAL_INT(1, idx);
 
-  adc_buffer_full_interrupt();
-
-  TEST_ASSERT_EQUAL(1, *_test_get_bit_index());
+  uint8_t* stream = _test_get_window_stream();
+  TEST_ASSERT_EQUAL_UINT8(1, stream[idx - 1]);
 }
 
-void test_adc_buffer_with_silence_does_not_append_bit(void) {
-  fill_dma_buffer(0);
-
-  // Disarm any prior state (feed several weak windows to clear history)
-  for (int i = 0; i < 6; ++i) {  // 6 is enough regardless of scan length
-    adc_buffer_full_interrupt();
-  }
-  // Now start fresh for this assertion
-  *_test_get_bit_index() = 0;
-  *_test_get_adc_window_counter() = 0;
-
-  adc_buffer_full_interrupt();
-  adc_buffer_full_interrupt();
-
-  uint16_t* copy = (uint16_t*)_test_get_adc_buffer_curr_half();
-  for (size_t i = 0; i < buffer_size; i++) {
-    TEST_ASSERT_EQUAL(0, copy[i]);
-  }
-
-  int idx = *_test_get_bit_index();
-  uint8_t* bits = _test_get_bitstream();
-
-  // Silence may append zero-bits; it must not produce any '1's.
-  for (int i = 0; i < idx; ++i) {
-    TEST_ASSERT_EQUAL(0, bits[i]);
-  }
-}
-
-void test_buffer_copy_max_values(void) {
+void test_isr_can_queue_two_windows_before_drain_and_produces_two_stream_entries(void) {
   prime_alignment_with_alternating_windows();
-  uint16_t* copy = (uint16_t*)_test_get_adc_buffer_curr_half();
-  fill_dma_buffer(UINT16_MAX);
-  adc_buffer_full_interrupt();
+  *_test_get_window_index() = 0;
+
+  // Queue two windows (queue depth is 2), drain once
+  fill_dma_with_sine(2200.0f);
   adc_buffer_full_interrupt();
 
-  // Confirms adc_buffer_full_bit	matches max pattern:
-  for (size_t i = 0; i < buffer_size; i++) {
-    TEST_ASSERT_EQUAL(UINT16_MAX, copy[i]);
-  }
+  fill_dma_with_sine(2200.0f);
+  adc_buffer_full_interrupt();
 
-  // Confirms that one bit was appended:
-  TEST_ASSERT_EQUAL(1, *_test_get_bit_index());
+  process_rx_windows();
+
+  int idx = *_test_get_window_index();
+  TEST_ASSERT_EQUAL_INT(2, idx);
+
+  uint8_t* stream = _test_get_window_stream();
+  TEST_ASSERT_EQUAL_UINT8(1, stream[0]);
+  TEST_ASSERT_EQUAL_UINT8(1, stream[1]);
 }
 
-void test_buffer_copy_alternating(void) {
+void test_silence_window_does_not_append_to_window_stream(void) {
   prime_alignment_with_alternating_windows();
-  uint16_t* copy = (uint16_t*)_test_get_adc_buffer_curr_half();
-  fill_dma_buffer(UINT16_MAX, true);
+  *_test_get_window_index() = 0;
+
+  // Pure silence → both mags should be under the gate → no append
+  fill_dma_constant(0);
   adc_buffer_full_interrupt();
-  adc_buffer_full_interrupt();
+  process_rx_windows();
 
-  // Confirms adc_buffer_full_bit matches alternating pattern:
-  for (size_t i = 0; i < buffer_size; i++) {
-    uint16_t expected = (i % 2 == 0) ? 0 : UINT16_MAX;
-    TEST_ASSERT_EQUAL(expected, copy[i]);
-  }
-
-  // Confirms bit extraction still ran:
-  TEST_ASSERT_EQUAL(1, *_test_get_bit_index());
-}
-
-void test_adc_window_counter_gating(void) {
-  // Sets adc_window_counter so that % SCAN_CHAIN_LENGTH != 0
-  *_test_get_adc_window_counter() = 1;  // Any nonzero value that fails the mod check
-
-  // Resets bit index:
-  *_test_get_bit_index() = 0;
-
-  adc_buffer_full_interrupt();
-  adc_buffer_full_interrupt();
-
-  // Since adc_window_counter gating skipped processing, bit_index should stay 0:
-  TEST_ASSERT_EQUAL(0, *_test_get_bit_index());
+  TEST_ASSERT_EQUAL_INT(0, *_test_get_window_index());
 }
 
 void setup() {
@@ -167,11 +110,9 @@ void setup() {
   while (!Serial && millis() < 5000);
 
   UNITY_BEGIN();
-  RUN_TEST(test_bit_extraction_triggered);
-  RUN_TEST(test_adc_buffer_with_silence_does_not_append_bit);
-  RUN_TEST(test_buffer_copy_max_values);
-  RUN_TEST(test_buffer_copy_alternating);
-  RUN_TEST(test_adc_window_counter_gating);
+  RUN_TEST(test_isr_queues_and_process_drains_one_window_into_window_stream);
+  RUN_TEST(test_isr_can_queue_two_windows_before_drain_and_produces_two_stream_entries);
+  RUN_TEST(test_silence_window_does_not_append_to_window_stream);
   UNITY_END();
 }
 

--- a/firmware/test/receiving/test_check_for_complete_packet/check_for_complete_packet.cpp
+++ b/firmware/test/receiving/test_check_for_complete_packet/check_for_complete_packet.cpp
@@ -1,8 +1,9 @@
 // ==================================================================
 // check_for_complete_packet.cpp
-// Input: bitstream[] (with bit_index bits)
+// Input: window_stream[] (window-level bit guesses) and window_index (count of windows)
 // Output: message (passed to deliver_message())
-// Run just this test with $ pio test -e teensy40_test -f "receiving/test_check_for_complete_packet"
+// Run just this test with:
+//  pio test -e teensy40_test -f "receiving/test_check_for_complete_packet"
 // ==================================================================
 #include <Arduino.h>
 #include <unity.h>

--- a/firmware/test/receiving/test_check_for_complete_packet/check_for_complete_packet.cpp
+++ b/firmware/test/receiving/test_check_for_complete_packet/check_for_complete_packet.cpp
@@ -11,131 +11,107 @@
 #include "comm.h"
 #include "mock_display.h"
 
+// Write a byte-aligned packet into window_stream.
+// IMPORTANT: each byte spans WINDOWS_PER_BIT * 8 windows.
+static void write_packet_bytes_into_window_stream(const uint8_t* bytes, size_t byte_len, int off = 0) {
+  uint8_t* ws = _test_get_window_stream();
+
+  const int BYTE_STRIDE = WINDOWS_PER_BIT * 8;
+
+  // Clear enough space so old data doesn't interfere
+  size_t total_windows = (size_t)off + (size_t)BYTE_STRIDE * byte_len;
+  for (size_t i = 0; i < total_windows; i++) {
+    ws[i] = 0;
+  }
+
+  for (size_t bi = 0; bi < byte_len; bi++) {
+    size_t base = (size_t)off + (size_t)BYTE_STRIDE * bi;
+    uint8_t byte = bytes[bi];
+
+    // MSB-first bits
+    for (int b = 0; b < 8; b++) {
+      uint8_t bit = (byte >> (7 - b)) & 1;
+
+      size_t bit_start = base + (size_t)WINDOWS_PER_BIT * b;
+      for (int w = 0; w < WINDOWS_PER_BIT; w++) {
+        ws[bit_start + (size_t)w] = bit;
+      }
+    }
+  }
+
+  *_test_get_window_index() = (int)total_windows; // window count
+}
+
 void setUp(void) {
-  // Resets counter before each test:
   display_called = 0;
 
-  // Redirects delivered messages to test buffer for verification during unit tests:
   _test_set_deliver_fn([](const char* msg) {
     strncpy(_test_get_delivered_message(), msg, MAX_TEXT_LENGTH);
+    _test_get_delivered_message()[MAX_TEXT_LENGTH - 1] = '\0';
   });
+
+  strcpy(_test_get_delivered_message(), "");
+  *_test_get_window_index() = 0;
 }
 
 void tearDown(void) {}
 
 void test_parses_message_when_valid_packet_present() {
-  // Set up valid packet: [START][H][i][END]
-  uint8_t test_bits[] = {
-    0,0,0,0,0,0,0,1,  // 0x01
-    0,0,0,0,0,0,1,0,  // 0x02
-    0,1,0,0,1,0,0,0,  // 'H'
-    0,1,1,0,1,0,0,1,  // 'i'
-    0,0,0,0,0,0,1,1,  // 0x03
-    0,0,0,0,0,1,0,0   // 0x04
+  const uint8_t bytes[] = {
+    PACKET_START1, PACKET_START2, 'H', 'i', PACKET_END1, PACKET_END2
   };
 
-  int* bit_index = _test_get_bit_index();
-  uint8_t* bitstream = _test_get_bitstream();
-
-  // Copy bits into test bitstream
-  for (size_t i = 0; i < sizeof(test_bits); i++) {
-    bitstream[i] = test_bits[i];
-  }
-  *bit_index = sizeof(test_bits);
-
-  // Reset captured message
-  strcpy(_test_get_delivered_message(), "");
+  write_packet_bytes_into_window_stream(bytes, sizeof(bytes));
 
   check_for_complete_packet();
 
-  // Confirm that the message "Hi" was parsed and delivered
   TEST_ASSERT_EQUAL_STRING("Hi", _test_get_delivered_message());
+  TEST_ASSERT_EQUAL(0, *_test_get_window_index());
 }
 
 void test_ignores_packet_with_no_framing() {
-  // Construct bitstream that lacks proper framing bytes
-  uint8_t bits[] = {
-    0,1,1,0,1,0,1,0,  // 0x6A
-    0,1,1,1,1,0,0,0,  // 0x78
-    0,1,0,0,1,0,1,0   // 0x4A
-  };
+  const uint8_t bytes[] = { 0x6A, 0x78, 0x4A };
 
-  int* bit_index = _test_get_bit_index();
-  uint8_t* bitstream = _test_get_bitstream();
-
-  for (size_t i = 0; i < sizeof(bits); i++) {
-    bitstream[i] = bits[i];
-  }
-  *bit_index = sizeof(bits);
-
-  // Clear any previous message
-  strcpy(_test_get_delivered_message(), "");
-
-  check_for_complete_packet();
-
-  // Confirm no message was parsed/delivered:
-  TEST_ASSERT_EQUAL_STRING("", _test_get_delivered_message());
-}
-
-void test_truncates_message_that_exceeds_max_length() {
-  // Construct message: [START][A x 410][END]
-  const int A_COUNT = MAX_PACKET_SIZE - 4;
-
-  static uint8_t test_bits[8 * (2 + A_COUNT + 2)];
-  size_t i = 0;
-
-  // Header bytes:
-  uint8_t start[] = {0x01, 0x02};
-  for (uint8_t b : start)
-    for (int j = 7; j >= 0; j--) test_bits[i++] = (b >> j) & 1;
-
-  // Message bytes:
-  for (int k = 0; k < A_COUNT; k++) {
-    uint8_t a = 'A';
-    for (int j = 7; j >= 0; j--) test_bits[i++] = (a >> j) & 1;
-  }
-
-  // Footer bytes:
-  uint8_t end[] = {0x03, 0x04};
-  for (uint8_t b : end)
-    for (int j = 7; j >= 0; j--) test_bits[i++] = (b >> j) & 1;
-
-  memcpy(_test_get_bitstream(), test_bits, i);
-  *_test_get_bit_index() = i;
-
-  check_for_complete_packet();
-
-  const char* delivered = _test_get_delivered_message();
-  TEST_ASSERT_EQUAL_INT(MAX_TEXT_LENGTH - 1, strlen(delivered));
-  TEST_ASSERT_EQUAL_CHAR('A', delivered[0]);
-}
-
-void test_does_not_check_for_complete_packet_with_only_start_header() {
-  uint8_t test_bits[] = {
-    0,0,0,0,0,0,0,1,
-    0,0,0,0,0,0,1,0
-  };
-
-  memcpy(_test_get_bitstream(), test_bits, sizeof(test_bits));
-  *_test_get_bit_index() = sizeof(test_bits);
-
-  strcpy(_test_get_delivered_message(), "");
+  write_packet_bytes_into_window_stream(bytes, sizeof(bytes));
 
   check_for_complete_packet();
 
   TEST_ASSERT_EQUAL_STRING("", _test_get_delivered_message());
 }
 
-void test_does_not_check_for_complete_packet_with_only_stop_footer() {
-  uint8_t test_bits[] = {
-    0,0,0,0,0,0,1,1,
-    0,0,0,0,0,1,0,0
-  };
+void test_rejects_message_that_exceeds_max_length() {
+  static uint8_t bytes[2 + MAX_TEXT_LENGTH + 2];
+  size_t idx = 0;
 
-  memcpy(_test_get_bitstream(), test_bits, sizeof(test_bits));
-  *_test_get_bit_index() = sizeof(test_bits);
+  bytes[idx++] = PACKET_START1;
+  bytes[idx++] = PACKET_START2;
+  for (int i = 0; i < MAX_TEXT_LENGTH; i++) {
+    bytes[idx++] = 'A';
+  }
+  bytes[idx++] = PACKET_END1;
+  bytes[idx++] = PACKET_END2;
 
-  strcpy(_test_get_delivered_message(), "");
+  write_packet_bytes_into_window_stream(bytes, idx);
+
+  check_for_complete_packet();
+
+  TEST_ASSERT_EQUAL_STRING("", _test_get_delivered_message());
+}
+
+void test_does_not_deliver_with_only_start_header() {
+  const uint8_t bytes[] = { PACKET_START1, PACKET_START2 };
+
+  write_packet_bytes_into_window_stream(bytes, sizeof(bytes));
+
+  check_for_complete_packet();
+
+  TEST_ASSERT_EQUAL_STRING("", _test_get_delivered_message());
+}
+
+void test_does_not_deliver_with_only_stop_footer() {
+  const uint8_t bytes[] = { PACKET_END1, PACKET_END2 };
+
+  write_packet_bytes_into_window_stream(bytes, sizeof(bytes));
 
   check_for_complete_packet();
 
@@ -143,21 +119,11 @@ void test_does_not_check_for_complete_packet_with_only_stop_footer() {
 }
 
 void test_ignores_noise_before_header() {
-  // Arbitrary bit sequence + [START][H][i][END]
-  uint8_t test_bits[] = {
-    1,1,1,1,1,1,1,1,
-    0,0,0,0,0,0,0,1,  // 0x01
-    0,0,0,0,0,0,1,0,  // 0x02
-    0,1,0,0,1,0,0,0,  // 'H'
-    0,1,1,0,1,0,0,1,  // 'i'
-    0,0,0,0,0,0,1,1,  // 0x03
-    0,0,0,0,0,1,0,0   // 0x04
+  const uint8_t bytes[] = {
+    0xFF, PACKET_START1, PACKET_START2, 'H', 'i', PACKET_END1, PACKET_END2
   };
 
-  memcpy(_test_get_bitstream(), test_bits, sizeof(test_bits));
-  *_test_get_bit_index() = sizeof(test_bits);
-
-  strcpy(_test_get_delivered_message(), "");
+  write_packet_bytes_into_window_stream(bytes, sizeof(bytes));
 
   check_for_complete_packet();
 
@@ -171,9 +137,8 @@ void setup() {
   UNITY_BEGIN();
   RUN_TEST(test_parses_message_when_valid_packet_present);
   RUN_TEST(test_ignores_packet_with_no_framing);
-  RUN_TEST(test_truncates_message_that_exceeds_max_length);
-  RUN_TEST(test_does_not_check_for_complete_packet_with_only_start_header);
-  RUN_TEST(test_does_not_check_for_complete_packet_with_only_stop_footer);
+  RUN_TEST(test_does_not_deliver_with_only_start_header);
+  RUN_TEST(test_does_not_deliver_with_only_stop_footer);
   RUN_TEST(test_ignores_noise_before_header);
   UNITY_END();
 }

--- a/firmware/test/receiving/test_check_for_complete_packet/check_for_complete_packet.cpp
+++ b/firmware/test/receiving/test_check_for_complete_packet/check_for_complete_packet.cpp
@@ -63,7 +63,10 @@ void test_parses_message_when_valid_packet_present() {
 
   write_packet_bytes_into_window_stream(bytes, sizeof(bytes));
 
-  check_for_complete_packet();
+  char msg_buf[MAX_TEXT_LENGTH];
+  if (check_for_complete_packet(msg_buf, sizeof(msg_buf)) > 0) {
+    deliver_message(msg_buf);
+  }
 
   TEST_ASSERT_EQUAL_STRING("Hi", _test_get_delivered_message());
   TEST_ASSERT_EQUAL(0, *_test_get_window_index());
@@ -74,7 +77,8 @@ void test_ignores_packet_with_no_framing() {
 
   write_packet_bytes_into_window_stream(bytes, sizeof(bytes));
 
-  check_for_complete_packet();
+  char msg_buf[MAX_TEXT_LENGTH];
+  check_for_complete_packet(msg_buf, sizeof(msg_buf));
 
   TEST_ASSERT_EQUAL_STRING("", _test_get_delivered_message());
 }
@@ -93,7 +97,8 @@ void test_rejects_message_that_exceeds_max_length() {
 
   write_packet_bytes_into_window_stream(bytes, idx);
 
-  check_for_complete_packet();
+  char msg_buf[MAX_TEXT_LENGTH];
+  check_for_complete_packet(msg_buf, sizeof(msg_buf));
 
   TEST_ASSERT_EQUAL_STRING("", _test_get_delivered_message());
 }
@@ -103,7 +108,8 @@ void test_does_not_deliver_with_only_start_header() {
 
   write_packet_bytes_into_window_stream(bytes, sizeof(bytes));
 
-  check_for_complete_packet();
+  char msg_buf[MAX_TEXT_LENGTH];
+  check_for_complete_packet(msg_buf, sizeof(msg_buf));
 
   TEST_ASSERT_EQUAL_STRING("", _test_get_delivered_message());
 }
@@ -113,7 +119,8 @@ void test_does_not_deliver_with_only_stop_footer() {
 
   write_packet_bytes_into_window_stream(bytes, sizeof(bytes));
 
-  check_for_complete_packet();
+  char msg_buf[MAX_TEXT_LENGTH];
+  check_for_complete_packet(msg_buf, sizeof(msg_buf));
 
   TEST_ASSERT_EQUAL_STRING("", _test_get_delivered_message());
 }
@@ -125,7 +132,10 @@ void test_ignores_noise_before_header() {
 
   write_packet_bytes_into_window_stream(bytes, sizeof(bytes));
 
-  check_for_complete_packet();
+  char msg_buf[MAX_TEXT_LENGTH];
+  if (check_for_complete_packet(msg_buf, sizeof(msg_buf)) > 0) {
+    deliver_message(msg_buf);
+  }
 
   TEST_ASSERT_EQUAL_STRING("Hi", _test_get_delivered_message());
 }

--- a/firmware/test/receiving/test_check_for_complete_packet/check_for_complete_packet.cpp
+++ b/firmware/test/receiving/test_check_for_complete_packet/check_for_complete_packet.cpp
@@ -1,8 +1,8 @@
 // ==================================================================
-// parse_message.cpp
+// check_for_complete_packet.cpp
 // Input: bitstream[] (with bit_index bits)
 // Output: message (passed to deliver_message())
-// Run just this test with $ pio test -e teensy40_test -f "receiving/test_parse_message"
+// Run just this test with $ pio test -e teensy40_test -f "receiving/test_check_for_complete_packet"
 // ==================================================================
 #include <Arduino.h>
 #include <unity.h>
@@ -45,7 +45,7 @@ void test_parses_message_when_valid_packet_present() {
   // Reset captured message
   strcpy(_test_get_delivered_message(), "");
 
-  parse_message();
+  check_for_complete_packet();
 
   // Confirm that the message "Hi" was parsed and delivered
   TEST_ASSERT_EQUAL_STRING("Hi", _test_get_delivered_message());
@@ -70,7 +70,7 @@ void test_ignores_packet_with_no_framing() {
   // Clear any previous message
   strcpy(_test_get_delivered_message(), "");
 
-  parse_message();
+  check_for_complete_packet();
 
   // Confirm no message was parsed/delivered:
   TEST_ASSERT_EQUAL_STRING("", _test_get_delivered_message());
@@ -102,14 +102,14 @@ void test_truncates_message_that_exceeds_max_length() {
   memcpy(_test_get_bitstream(), test_bits, i);
   *_test_get_bit_index() = i;
 
-  parse_message();
+  check_for_complete_packet();
 
   const char* delivered = _test_get_delivered_message();
   TEST_ASSERT_EQUAL_INT(MAX_TEXT_LENGTH - 1, strlen(delivered));
   TEST_ASSERT_EQUAL_CHAR('A', delivered[0]);
 }
 
-void test_does_not_parse_message_with_only_start_header() {
+void test_does_not_check_for_complete_packet_with_only_start_header() {
   uint8_t test_bits[] = {
     0,0,0,0,0,0,0,1,
     0,0,0,0,0,0,1,0
@@ -120,12 +120,12 @@ void test_does_not_parse_message_with_only_start_header() {
 
   strcpy(_test_get_delivered_message(), "");
 
-  parse_message();
+  check_for_complete_packet();
 
   TEST_ASSERT_EQUAL_STRING("", _test_get_delivered_message());
 }
 
-void test_does_not_parse_message_with_only_stop_footer() {
+void test_does_not_check_for_complete_packet_with_only_stop_footer() {
   uint8_t test_bits[] = {
     0,0,0,0,0,0,1,1,
     0,0,0,0,0,1,0,0
@@ -136,7 +136,7 @@ void test_does_not_parse_message_with_only_stop_footer() {
 
   strcpy(_test_get_delivered_message(), "");
 
-  parse_message();
+  check_for_complete_packet();
 
   TEST_ASSERT_EQUAL_STRING("", _test_get_delivered_message());
 }
@@ -158,12 +158,10 @@ void test_ignores_noise_before_header() {
 
   strcpy(_test_get_delivered_message(), "");
 
-  parse_message();
+  check_for_complete_packet();
 
   TEST_ASSERT_EQUAL_STRING("Hi", _test_get_delivered_message());
 }
-
-
 
 void setup() {
   Serial.begin(9600);
@@ -173,8 +171,8 @@ void setup() {
   RUN_TEST(test_parses_message_when_valid_packet_present);
   RUN_TEST(test_ignores_packet_with_no_framing);
   RUN_TEST(test_truncates_message_that_exceeds_max_length);
-  RUN_TEST(test_does_not_parse_message_with_only_start_header);
-  RUN_TEST(test_does_not_parse_message_with_only_stop_footer);
+  RUN_TEST(test_does_not_check_for_complete_packet_with_only_start_header);
+  RUN_TEST(test_does_not_check_for_complete_packet_with_only_stop_footer);
   RUN_TEST(test_ignores_noise_before_header);
   UNITY_END();
 }

--- a/firmware/test/receiving/test_decode_single_bit_from_adc_window/decode_single_bit_from_adc_window.cpp
+++ b/firmware/test/receiving/test_decode_single_bit_from_adc_window/decode_single_bit_from_adc_window.cpp
@@ -44,37 +44,9 @@ void setUp(void) {
 
 void tearDown(void) {}
 
-// void test_decoding_single_bit_increments_bitstream_index(void) {
-//   *_test_get_adc_window_counter() = 0;
-//   prime_phase_for_decode();
-//   // Force alignment so next decode call lands on the chosen phase
-//   *_test_get_adc_window_counter() = bit_alignment_phase;
-
-
-//   // Fills ADC buffer with a strong 2200 Hz sine wave:
-//   float frequency = 2200.0f;
-//   float sampling_rate = 81920.0f;
-//   float amplitude = 1500.0f;
-//   float offset = 2048.0f;
-
-//   // Try up to 3 consecutive windows so one lands on the decode phase
-//   for (int tries = 0; tries < 3 && *_test_get_bit_index() == 0; ++tries) {
-//     for (uint32_t i = 0; i < buffer_size; i++) {
-//       float t = (float)i / sampling_rate;
-//       mock_adc_buffer[i] = (uint16_t)(offset + amplitude * sinf(2.0f * PI * frequency * t));
-//     }
-//     decode_single_bit_from_adc_window(mock_adc_buffer, buffer_size);
-//   }
-
-//   // We expect at least one bit by now
-//   TEST_ASSERT_TRUE_MESSAGE(*_test_get_bit_index() > 0,
-//     "Expected a bit after priming + up to 3 aligned windows");
-
-// }
-
 void test_skips_decoding_when_gating_fails(void) {
   // Sets adc_window_counter to 1, which is not a multiple of SCAN_CHAIN_LENGTH and therefore the decoding logic shouldn't run:
-  *_test_get_adc_window_counter() = 1; 
+  *_test_get_adc_window_counter() = 1;
 
   // Fill mock buffer with dummy data:
   for (size_t i = 0; i < mock_adc_buffer_size; i++) {
@@ -148,7 +120,6 @@ void setup() {
   while (!Serial && millis() < 5000);
 
   UNITY_BEGIN();
-  // RUN_TEST(test_decoding_single_bit_increments_bitstream_index);
   RUN_TEST(test_skips_decoding_when_gating_fails);
   RUN_TEST(test_correct_bit_extracted_from_strongest_freq);
   RUN_TEST(test_goertzel_states_reset_after_decode);

--- a/firmware/test/receiving/test_decode_single_bit_from_adc_window/decode_single_bit_from_adc_window.cpp
+++ b/firmware/test/receiving/test_decode_single_bit_from_adc_window/decode_single_bit_from_adc_window.cpp
@@ -3,7 +3,7 @@
 // Input: Filled ADC samples and current Goertzel states
 // Output: Appends a decoded bit to window_stream[] and checks for packet completion
 // Run just this test with:
-//   pio test -e teensy40_test -f "receiving/test_decode_single_bit_from_adc_window"
+//  pio test -e teensy40_test -f "receiving/test_decode_single_bit_from_adc_window"
 // ==================================================================
 #include <Arduino.h>
 #include <unity.h>

--- a/firmware/test/receiving/test_decode_single_bit_from_adc_window/decode_single_bit_from_adc_window.cpp
+++ b/firmware/test/receiving/test_decode_single_bit_from_adc_window/decode_single_bit_from_adc_window.cpp
@@ -1,8 +1,9 @@
 // ==================================================================
 // decode_single_bit_from_adc_window.cpp
 // Input: Filled ADC samples and current Goertzel states
-// Output: Appends a decoded bit to bitstream[] and parses message
-// Run just this test with $ pio test -e teensy40_test -f "receiving/test_decode_single_bit_from_adc_window"
+// Output: Appends a decoded bit to window_stream[] and checks for packet completion
+// Run just this test with:
+//   pio test -e teensy40_test -f "receiving/test_decode_single_bit_from_adc_window"
 // ==================================================================
 #include <Arduino.h>
 #include <unity.h>
@@ -10,9 +11,10 @@
 #include "comm.h"
 #include "goertzel.h"
 
-static uint16_t mock_adc_buffer[410 * 2]; // 2 full windows worth of samples
-static const size_t mock_adc_buffer_size = sizeof(mock_adc_buffer) / sizeof(mock_adc_buffer[0]);
+static uint16_t mock_adc_buffer[410];
 
+// Helper func/fixture that feeds alternating windows so find_bit_boundaries() can lock
+// because decode_single_bit_from_adc_window() depends on state built up across previous windows.
 static void prime_phase_for_decode() {
   const float sr = 81920.0f, amp = 1500.0f, off = 2048.0f;
 
@@ -25,90 +27,76 @@ static void prime_phase_for_decode() {
     decode_single_bit_from_adc_window(mock_adc_buffer, buffer_size);
   }
 
-  // Clean slate for assertions (keep adc_window_counter as-is for phase).
-  *_test_get_bit_index() = 0;
+  *_test_get_window_index() = 0;
 }
 
 void setUp(void) {
-  // Ensures decode_single_bit_from_adc_window processes data on first call:
+  // Resets indices/state the tests directly rely on:
+  *_test_get_window_index() = 0;
   *_test_get_adc_window_counter() = 0;
 
-  // Resets bitstream index:
-  *_test_get_bit_index() = 0;
-
-  // Normally this happens in setup_receiver(), but we don’t call that in tests because it configures ADC, DMA, and other hardware:
-  initialize_goertzel(&_test_get_goertzel_state()[0], 2000, 81920);  // freq 0
-  initialize_goertzel(&_test_get_goertzel_state()[1], 2200, 81920);  // freq 1
-
+  // Initializes the two Goertzel bins (normally done in setup_receiver()).
+  initialize_goertzel(&_test_get_goertzel_state()[0], 2000, 81920);
+  initialize_goertzel(&_test_get_goertzel_state()[1], 2200, 81920);
 }
 
 void tearDown(void) {}
 
-void test_skips_decoding_when_gating_fails(void) {
-  // Sets adc_window_counter to 1, which is not a multiple of SCAN_CHAIN_LENGTH and therefore the decoding logic shouldn't run:
-  *_test_get_adc_window_counter() = 1;
-
-  // Fill mock buffer with dummy data:
-  for (size_t i = 0; i < mock_adc_buffer_size; i++) {
-    mock_adc_buffer[i] = 2000;
+void test_skips_decoding_when_signal_is_too_weak(void) {
+  // All-zero samples => Goertzel outputs magnitude ~0 for both bins,
+  // which triggers the MIN_TONE_MAGNITUDE early return path.
+  for (uint32_t i = 0; i < buffer_size; ++i) {
+    mock_adc_buffer[i] = 0;
   }
 
-  decode_single_bit_from_adc_window(mock_adc_buffer, mock_adc_buffer_size);
+  decode_single_bit_from_adc_window(mock_adc_buffer, buffer_size);
 
-  // If the bit index hasn't been incremented, we know the decoding logic was skipped:
-  TEST_ASSERT_EQUAL(0, *_test_get_bit_index());
+  // Should not append any bits.
+  TEST_ASSERT_EQUAL(0, *_test_get_window_index());
 }
 
-void test_correct_bit_extracted_from_strongest_freq(void) {
-  *_test_get_adc_window_counter() = 0;
+void test_correct_bit_extracted_after_alignment_locks(void) {
   prime_phase_for_decode();
 
-  // Simulates Goertzel output: stronger signal at index 1 (freq 1)
-  // freq 0 → magnitude = 3; freq 1 → magnitude = 10
-  goertzel_state* gs = _test_get_goertzel_state();
-  gs[0].y_re =   3; gs[0].y_im = 0;
-  gs[1].y_re = 100; gs[1].y_im = 0;
+  // Now feeds a strong 2.2kHz window. Once alignment is locked, the code appends
+  // one bit per window. We expect a '1' because 2.2kHz bin should win.
+  const float sr = 81920.0f, amp = 1500.0f, off = 2048.0f;
+  const float f = 2200.0f;
 
-  float frequency = 2200.0f;
-  float sampling_rate = 81920.0f;
-  float amplitude = 1500.0f;
-  float offset = 2048.0f;
-
-  for (uint32_t i = 0; i < buffer_size * 2; i++) {
-    float t = (float)i / sampling_rate;
-    float sine = sinf(2.0f * PI * frequency * t);
-    mock_adc_buffer[i] = (uint16_t)(offset + amplitude * sine);
+  for (uint32_t i = 0; i < buffer_size; ++i) {
+    float t = (float)i / sr;
+    mock_adc_buffer[i] = (uint16_t)(off + amp * sinf(2.0f * PI * f * t));
   }
 
-  decode_single_bit_from_adc_window(mock_adc_buffer, mock_adc_buffer_size);
+  decode_single_bit_from_adc_window(mock_adc_buffer, buffer_size);
 
-  uint8_t* bitstream = _test_get_bitstream();
-  // Expect freq with magnitude 10 to get picked, so the first bit should be a 1:
+  uint8_t* bitstream = _test_get_window_stream();
+  TEST_ASSERT_EQUAL(1, *_test_get_window_index());
   TEST_ASSERT_EQUAL(1, bitstream[0]);
 }
 
-void test_goertzel_states_reset_after_decode() {
-  *_test_get_adc_window_counter() = 0;
-
+void test_goertzel_states_reset_after_decode(void) {
   goertzel_state* gs = _test_get_goertzel_state();
 
-  // Gives the filters some non-zero internal state:
-  for (int i = 0; i < 10; i++) {
+  for (int i = 0; i < 2; i++) {
     gs[i].s = 1.0f;
     gs[i].s_z1 = 1.0f;
     gs[i].n = 5;
   }
 
-  // Fill ADC buffer with valid data:
-  for (size_t i = 0; i < mock_adc_buffer_size; i++) {
-    mock_adc_buffer[i] = 2000;
+  // Feeds a valid non-weak window so we reach the reset_goertzel() call at end.
+  // (Use a tone rather than constant, but any non-zero input will do here.)
+  const float sr = 81920.0f, amp = 1500.0f, off = 2048.0f;
+  const float f = 2000.0f;
+
+  for (uint32_t i = 0; i < buffer_size; ++i) {
+    float t = (float)i / sr;
+    mock_adc_buffer[i] = (uint16_t)(off + amp * sinf(2.0f * PI * f * t));
   }
 
-  // Tests that after each bit is decoded, reset_goertzel is doing what it's supposed to be doing:
-  decode_single_bit_from_adc_window(mock_adc_buffer, mock_adc_buffer_size);
+  decode_single_bit_from_adc_window(mock_adc_buffer, buffer_size);
 
-  // After decoding, these internal states should be cleared:
-  for (int i = 0; i < 10; i++) {
+  for (int i = 0; i < 2; i++) {
     TEST_ASSERT_EQUAL_FLOAT(0.0f, gs[i].s);
     TEST_ASSERT_EQUAL_FLOAT(0.0f, gs[i].s_z1);
     TEST_ASSERT_EQUAL(0, gs[i].n);
@@ -120,8 +108,8 @@ void setup() {
   while (!Serial && millis() < 5000);
 
   UNITY_BEGIN();
-  RUN_TEST(test_skips_decoding_when_gating_fails);
-  RUN_TEST(test_correct_bit_extracted_from_strongest_freq);
+  RUN_TEST(test_skips_decoding_when_signal_is_too_weak);
+  RUN_TEST(test_correct_bit_extracted_after_alignment_locks);
   RUN_TEST(test_goertzel_states_reset_after_decode);
   UNITY_END();
 }

--- a/firmware/test/receiving/test_decode_single_bit_from_adc_window/decode_single_bit_from_adc_window.cpp
+++ b/firmware/test/receiving/test_decode_single_bit_from_adc_window/decode_single_bit_from_adc_window.cpp
@@ -10,6 +10,25 @@
 #include "comm.h"
 #include "goertzel.h"
 
+static uint16_t mock_adc_buffer[410 * 2]; // 2 full windows worth of samples
+static const size_t mock_adc_buffer_size = sizeof(mock_adc_buffer) / sizeof(mock_adc_buffer[0]);
+
+static void prime_phase_for_decode() {
+  const float sr = 81920.0f, amp = 1500.0f, off = 2048.0f;
+
+  for (int w = 0; w < 7; ++w) {
+    const float f = (w % 2 == 0) ? 2000.0f : 2200.0f;
+    for (uint32_t i = 0; i < buffer_size; ++i) {
+      float t = (float)i / sr;
+      mock_adc_buffer[i] = (uint16_t)(off + amp * sinf(2.0f * PI * f * t));
+    }
+    decode_single_bit_from_adc_window(mock_adc_buffer, buffer_size);
+  }
+
+  // Clean slate for assertions (keep adc_window_counter as-is for phase).
+  *_test_get_bit_index() = 0;
+}
+
 void setUp(void) {
   // Ensures decode_single_bit_from_adc_window processes data on first call:
   *_test_get_adc_window_counter() = 0;
@@ -25,46 +44,58 @@ void setUp(void) {
 
 void tearDown(void) {}
 
-void test_decoding_single_bit_increments_bitstream_index(void) {
-  *_test_get_adc_window_counter() = 0;
+// void test_decoding_single_bit_increments_bitstream_index(void) {
+//   *_test_get_adc_window_counter() = 0;
+//   prime_phase_for_decode();
+//   // Force alignment so next decode call lands on the chosen phase
+//   *_test_get_adc_window_counter() = bit_alignment_phase;
 
-  // Fills ADC buffer with a strong 2200 Hz sine wave:
-  float frequency = 2200.0f;
-  float sampling_rate = 81920.0f;
-  float amplitude = 1500.0f;
-  float offset = 2048.0f;
 
-  uint16_t* adc_buffer = _test_get_adc_buffer_full_bit();
-  for (uint32_t i = 0; i < buffer_size * 2; i++) {
-    float t = (float)i / sampling_rate;
-    float sine = sinf(2.0f * PI * frequency * t);
-    adc_buffer[i] = (uint16_t)(offset + amplitude * sine);
-  }
+//   // Fills ADC buffer with a strong 2200 Hz sine wave:
+//   float frequency = 2200.0f;
+//   float sampling_rate = 81920.0f;
+//   float amplitude = 1500.0f;
+//   float offset = 2048.0f;
 
-  decode_single_bit_from_adc_window();
+//   // Try up to 3 consecutive windows so one lands on the decode phase
+//   for (int tries = 0; tries < 3 && *_test_get_bit_index() == 0; ++tries) {
+//     for (uint32_t i = 0; i < buffer_size; i++) {
+//       float t = (float)i / sampling_rate;
+//       mock_adc_buffer[i] = (uint16_t)(offset + amplitude * sinf(2.0f * PI * frequency * t));
+//     }
+//     decode_single_bit_from_adc_window(mock_adc_buffer, buffer_size);
+//   }
 
-  TEST_ASSERT_EQUAL(1, *_test_get_bit_index());
-}
+//   // We expect at least one bit by now
+//   TEST_ASSERT_TRUE_MESSAGE(*_test_get_bit_index() > 0,
+//     "Expected a bit after priming + up to 3 aligned windows");
 
+// }
 
 void test_skips_decoding_when_gating_fails(void) {
   // Sets adc_window_counter to 1, which is not a multiple of SCAN_CHAIN_LENGTH and therefore the decoding logic shouldn't run:
-  *_test_get_adc_window_counter() = 1;
+  *_test_get_adc_window_counter() = 1; 
 
-  decode_single_bit_from_adc_window();
+  // Fill mock buffer with dummy data:
+  for (size_t i = 0; i < mock_adc_buffer_size; i++) {
+    mock_adc_buffer[i] = 2000;
+  }
+
+  decode_single_bit_from_adc_window(mock_adc_buffer, mock_adc_buffer_size);
 
   // If the bit index hasn't been incremented, we know the decoding logic was skipped:
   TEST_ASSERT_EQUAL(0, *_test_get_bit_index());
 }
 
 void test_correct_bit_extracted_from_strongest_freq(void) {
+  *_test_get_adc_window_counter() = 0;
+  prime_phase_for_decode();
+
   // Simulates Goertzel output: stronger signal at index 1 (freq 1)
   // freq 0 → magnitude = 3; freq 1 → magnitude = 10
   goertzel_state* gs = _test_get_goertzel_state();
   gs[0].y_re =   3; gs[0].y_im = 0;
   gs[1].y_re = 100; gs[1].y_im = 0;
-
-  uint16_t* adc_buffer = _test_get_adc_buffer_full_bit	();
 
   float frequency = 2200.0f;
   float sampling_rate = 81920.0f;
@@ -74,10 +105,10 @@ void test_correct_bit_extracted_from_strongest_freq(void) {
   for (uint32_t i = 0; i < buffer_size * 2; i++) {
     float t = (float)i / sampling_rate;
     float sine = sinf(2.0f * PI * frequency * t);
-    adc_buffer[i] = (uint16_t)(offset + amplitude * sine);
+    mock_adc_buffer[i] = (uint16_t)(offset + amplitude * sine);
   }
 
-  decode_single_bit_from_adc_window();
+  decode_single_bit_from_adc_window(mock_adc_buffer, mock_adc_buffer_size);
 
   uint8_t* bitstream = _test_get_bitstream();
   // Expect freq with magnitude 10 to get picked, so the first bit should be a 1:
@@ -85,6 +116,8 @@ void test_correct_bit_extracted_from_strongest_freq(void) {
 }
 
 void test_goertzel_states_reset_after_decode() {
+  *_test_get_adc_window_counter() = 0;
+
   goertzel_state* gs = _test_get_goertzel_state();
 
   // Gives the filters some non-zero internal state:
@@ -94,8 +127,13 @@ void test_goertzel_states_reset_after_decode() {
     gs[i].n = 5;
   }
 
+  // Fill ADC buffer with valid data:
+  for (size_t i = 0; i < mock_adc_buffer_size; i++) {
+    mock_adc_buffer[i] = 2000;
+  }
+
   // Tests that after each bit is decoded, reset_goertzel is doing what it's supposed to be doing:
-  decode_single_bit_from_adc_window();
+  decode_single_bit_from_adc_window(mock_adc_buffer, mock_adc_buffer_size);
 
   // After decoding, these internal states should be cleared:
   for (int i = 0; i < 10; i++) {
@@ -110,7 +148,7 @@ void setup() {
   while (!Serial && millis() < 5000);
 
   UNITY_BEGIN();
-  RUN_TEST(test_decoding_single_bit_increments_bitstream_index);
+  // RUN_TEST(test_decoding_single_bit_increments_bitstream_index);
   RUN_TEST(test_skips_decoding_when_gating_fails);
   RUN_TEST(test_correct_bit_extracted_from_strongest_freq);
   RUN_TEST(test_goertzel_states_reset_after_decode);

--- a/firmware/test/receiving/test_deliver_message/deliver_message.cpp
+++ b/firmware/test/receiving/test_deliver_message/deliver_message.cpp
@@ -2,7 +2,8 @@
 // deliver_message.cpp
 // Input: A const char* message (the string to deliver)
 // Output: Updates chat history, updates display with that message
-// Run just this test with $ pio test -e teensy40_test -f "receiving/test_deliver_message"
+// Run just this test with:
+//  pio test -e teensy40_test -f "receiving/test_deliver_message"
 // ==================================================================
 #include <Arduino.h>
 #include <unity.h>

--- a/firmware/test/receiving/test_get_bit_from_top_frequency/get_bit_from_top_frequency.cpp
+++ b/firmware/test/receiving/test_get_bit_from_top_frequency/get_bit_from_top_frequency.cpp
@@ -1,8 +1,9 @@
 // ==================================================================
 // get_bit_from_top_frequency.cpp
 // Input: Goertzel frequency magnitudes in gs[]
-// Output: Appends a 0 or 1 to bitstream[] based on dominant frequency
-// Run just this test with $ pio test -e teensy40_test -f "receiving/test_get_bit_from_top_frequency"
+// Output: Appends a 0 or 1 based on dominant frequency
+// Run just this test with:
+//  pio test -e teensy40_test -f "receiving/test_get_bit_from_top_frequency"
 // ==================================================================
 #include <Arduino.h>
 #include <unity.h>

--- a/firmware/test/receiving/test_get_bit_from_top_frequency/get_bit_from_top_frequency.cpp
+++ b/firmware/test/receiving/test_get_bit_from_top_frequency/get_bit_from_top_frequency.cpp
@@ -58,7 +58,7 @@ void test_get_bit_from_top_frequency_does_not_overflow_buffer(void) {
 
 void test_get_bit_from_top_frequency_appends_correct_bit(void) {
   prime_phase_with_alternating_bins();
-  
+
   // Returns a pointer to the internal array of goertzel_state structs:
   goertzel_state* gs = _test_get_goertzel_state();
 

--- a/firmware/test/receiving/test_get_bit_from_top_frequency/get_bit_from_top_frequency.cpp
+++ b/firmware/test/receiving/test_get_bit_from_top_frequency/get_bit_from_top_frequency.cpp
@@ -24,11 +24,11 @@ static void prime_phase_with_alternating_bins() {
     get_bit_from_top_frequency(); // records window history; won’t append yet
   }
   // Reset bit index in case any previous state existed
-  *_test_get_bit_index() = 0;
+  *_test_get_window_index() = 0;
 }
 
 void setUp(void) {
-  *_test_get_bit_index() = 0;
+  *_test_get_window_index() = 0;
 }
 
 void tearDown(void) {
@@ -42,19 +42,19 @@ void test_get_bit_from_top_frequency_sets_bit_to_0_when_mag0_is_stronger(void) {
 
   get_bit_from_top_frequency();
 
-  TEST_ASSERT_EQUAL_UINT8(0, _test_get_bitstream()[0]);
+  TEST_ASSERT_EQUAL_UINT8(0, _test_get_window_stream()[0]);
 }
 
 void test_get_bit_from_top_frequency_does_not_overflow_buffer(void) {
   // Pretends buffer is full:
   static const int MAX_BITS = 256;
-  *_test_get_bit_index() = MAX_BITS;
+  *_test_get_window_index() = MAX_BITS;
 
   // This shouldn't append anything:
   get_bit_from_top_frequency();
 
   // Checks that index didn't change:
-  TEST_ASSERT_EQUAL(MAX_BITS, *_test_get_bit_index());
+  TEST_ASSERT_EQUAL(MAX_BITS, *_test_get_window_index());
 }
 
 void test_get_bit_from_top_frequency_appends_correct_bit(void) {
@@ -71,7 +71,7 @@ void test_get_bit_from_top_frequency_appends_correct_bit(void) {
 
   get_bit_from_top_frequency();
 
-  TEST_ASSERT_EQUAL_UINT8(0x1, _test_get_bitstream()[0]);
+  TEST_ASSERT_EQUAL_UINT8(0x1, _test_get_window_stream()[0]);
 }
 
 

--- a/firmware/test/receiving/test_get_bit_from_top_frequency/get_bit_from_top_frequency.cpp
+++ b/firmware/test/receiving/test_get_bit_from_top_frequency/get_bit_from_top_frequency.cpp
@@ -9,6 +9,23 @@
 
 #include "comm.h"
 
+static void prime_phase_with_alternating_bins() {
+  goertzel_state* gs = _test_get_goertzel_state();
+  // Alternate 2.0 kHz strong (bin 0) and 2.2 kHz strong (bin 1)
+  for (int i = 0; i < 7; ++i) {
+    if ((i % 2) == 0) { // even -> bin0 stronger
+      gs[0].y_re = 120.0f; gs[0].y_im = 0.0f;
+      gs[1].y_re =   2.0f; gs[1].y_im = 0.0f;
+    } else {            // odd -> bin1 stronger
+      gs[0].y_re =   2.0f; gs[0].y_im = 0.0f;
+      gs[1].y_re = 120.0f; gs[1].y_im = 0.0f;
+    }
+    get_bit_from_top_frequency(); // records window history; won’t append yet
+  }
+  // Reset bit index in case any previous state existed
+  *_test_get_bit_index() = 0;
+}
+
 void setUp(void) {
   *_test_get_bit_index() = 0;
 }
@@ -40,6 +57,8 @@ void test_get_bit_from_top_frequency_does_not_overflow_buffer(void) {
 }
 
 void test_get_bit_from_top_frequency_appends_correct_bit(void) {
+  prime_phase_with_alternating_bins();
+  
   // Returns a pointer to the internal array of goertzel_state structs:
   goertzel_state* gs = _test_get_goertzel_state();
 


### PR DESCRIPTION
 This MR completes and stabilizes the RX decoding path for the FSK protocol. The core fix was reworking packet reconstruction to handle byte-boundary misalignment by attempting all 16 possible window offsets (2 windows/bit × 8 bits/byte), which resolved dropped messages when alignment drifted. Along the way, the RX bitstream was correctly modeled as a window-level stream, receiver state reset logic was clarified, excessive debug/test hooks that interfered with timing were removed or disabled, tests were repaired, and comments were audited for technical accuracy. Result: the receiver now reliably parses repeated transmissions (tested with a “hello” signal looped every 4s) end-to-end, including display output.
 
 **1. Startup wires the receiver**
  - `setup_receiver()` configures the ADC, sets the charge amplifier gain, initializes two Goertzel detectors (2.0 kHz and 2.2 kHz), and sets up DMA.
  - DMA fills one chunk of samples (stored in `adc_dma_window`), triggers the interrupt, then is restarted to capture the next chunk.
  - An interrupt (`adc_buffer_full_interrupt`) is attached to fire whenever one full window of samples is captured.

**2. DMA interrupt captures raw audio windows**
  - `adc_buffer_full_interrupt()` runs when a full sample window is ready.
  - Cache is invalidated so the CPU sees the new samples.
  - The window is copied into a two-slot queue in fast RAM (RAM1).
  - If the queue is full, the window is dropped (Note: If a sample window is dropped, the receiver doesn't try to fix it right away; it keeps listening and re-syncs later when it sees the preamble pattern again).

**3. Main loop processes received windows**
  - The main `loop()` regularly checks for new audio windows by repeatedly calling `process_rx_windows()`.
  - When windows are waiting, it pulls them out of the queue one by one.
  - Each window is sent to `decode_single_bit_from_adc_window()` to figure out what it contains.

**4. Per-window processing checks which tone is present**
  - `decode_single_bit_from_adc_window()` looks at one ADC sample window at a time.
  - It measures how strong the 2.0 kHz tone is and how strong the 2.2 kHz tone is - if both tones are very weak (arbitrarily setting a threshold of 1 for `MIN_TONE_MAGNITUDE` for testing - probably need to increase this), the window is treated as noise and ignored. If not, `get_bit_from_top_frequency` and `check_for_complete_packet` are called for this window.

**5. Receiver figures out bit timing from the preamble**
  - For each valid window, `get_bit_from_top_frequency` stores the window’s
    tone information into a rolling history buffer
    (`goertzel_history_circ_buffer`).
  - The receiver waits until this history buffer has enough windows before
    attempting timing detection (`have_enough_windows`).
  - `find_bit_boundaries` looks through the recent window history and first checks that the signal is strong enough overall according to `MAGNITUDE_THRESHOLD` (Note: `MIN_TONE_MAGNITUDE` is a single-window (sample-level) gate, while `MAGNITUDE_THRESHOLD` is a multi-window (bit-timing-level) gate that checks the signal is stable over time before locking alignment. Probably need to change this as I arbitrarily set it at 5 for testing).
  - `find_bit_boundaries` then tries two possible alignments (starting on window 0 or window 1); for each case, it looks at windows in pairs and checks whether the detected tone flips between the two frequencies (an alternating pattern).
  - If it sees this alternating pattern several times in a row, it assumes this
    matches the preamble and locks in that alignment as the correct bit boundary (`bit_boundaries_are_known`).
  - If alignment is found (bails out if not), `get_bit_from_top_frequency()` uses the chosen
    alignment phase to decide which incoming windows count as real bit samples
    and starts emitting bits.
  - While emitting bits, it keeps checking that the signal stays strong enough;
    if the signal weakens for too long, it drops alignment and returns to waiting
    for the preamble.
  - Note that until alignment is found, no bits are treated as real data.

**6. Bit stream is scanned for a framed packet**
  - `check_for_complete_packet()` tries 16 different starting offsets (`offset = 0..15`)
    because a byte is 8 bits and each bit is sampled every `WINDOWS_PER_BIT` windows
    (8 * 2 = 16 windows per byte).
  - For each offset, it rebuilds bytes MSB-first into `decoded_bytes[]` by taking one bit
    every 2 windows: `bit = window_stream[i + WINDOWS_PER_BIT * b]`, then `byte = (byte << 1) | bit`.
  - It then scans `decoded_bytes[]` for the 2-byte header (`PACKET_START1`,`PACKET_START2`)
    and the 2-byte footer (`PACKET_END1`,`PACKET_END2`).
  - If it finds both, it copies the payload into the caller-provided message[], null-terminates it, returns the payload length, and sets window_index = 0. The caller (e.g. decode_single_bit_from_adc_window or process_rx_windows) then calls deliver_message(message) when the return value is greater than zero.

**7. Message is delivered to the chat system**
  - `deliver_message` first checks that the message length is valid
    (not empty and not longer than `MAX_MESSAGE_LENGTH`).
  - It scans the message to make sure all characters are printable ASCII and
    rejects anything invalid.
  - If the message passes these checks, it is added to the chat history buffer
    (`chat_history[]`) and the message count is updated.
  - The display is then refreshed so the new message appears on screen.




